### PR TITLE
Use undefined as valid array schema inner optional parse subject

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,10 +88,8 @@ Will extend base detailed schema type with another type intersection.
 
 `SubjT_V` is shortened `SubjectTypeValidated`. `SubjT_P` is shortened `SujbectTypeParsed`. Used in conjunction with `Con_` prefix. Both suffixes representing schema subject type depending on the schema subject check method: parse or validate. We support two flows of type inference for two main reasons:
 
-- Validate flow returns reference to original object without any mutations on success validation so we can't omit `undefined` values from the `Array` of validation flow if user specified optional schema as the array schema child.
-- Parse flow returns deep copy of parsed object:
-  - The parse flow can populate absent object key values with `default` specified in the corresponding property value schema
-  - The runtime parser just ignores non specified optional values
+- Validate flow returns reference to original object without any mutations.
+- Parse flow returns deep copy of parsed object, replaces `null` with `undefined` and `undefined` with schema `default` value.
 
 Because `default` value can be specified on base detailed schema ground level (`BD_Schema`) all type constructors for all base detailed and compound schema subject type will be split accordingly.
 

--- a/src/general-schema-parser.ts
+++ b/src/general-schema-parser.ts
@@ -113,9 +113,7 @@ export function parse(
       continue
     }
 
-    if (parsed.data !== undefined) {
-      result.push(parsed.data)
-    }
+    result.push(parsed.data)
   }
 
   if (errors.length) {

--- a/src/test/general-schema-parser.test.ts
+++ b/src/test/general-schema-parser.test.ts
@@ -100,7 +100,7 @@ describe('Parse BASE schema with INVALID subject', () => {
     const undefinedSubj = undefined
 
     expect(parse(shortReqStrSchema, undefinedSubj).data).toBe(undefined)
-    expect(parse(shortReqStrSchema, undefinedSubj).error).toEqual([
+    expect(parse(shortReqStrSchema, undefinedSubj).error).toStrictEqual([
       {
         code: PARSE_ERROR_CODE.invalidType,
         subject: undefinedSubj,
@@ -113,7 +113,7 @@ describe('Parse BASE schema with INVALID subject', () => {
     const numberSubj = 0
 
     expect(parse(shortOptStrSchema, numberSubj).data).toBe(undefined)
-    expect(parse(shortOptStrSchema, numberSubj).error).toEqual([
+    expect(parse(shortOptStrSchema, numberSubj).error).toStrictEqual([
       {
         code: PARSE_ERROR_CODE.invalidType,
         subject: numberSubj,
@@ -128,7 +128,7 @@ describe('Parse BASE schema with INVALID subject', () => {
     const undefinedSubj = undefined
 
     expect(parse(detailedReqStrSchema, undefinedSubj).data).toBe(undefined)
-    expect(parse(detailedReqStrSchema, undefinedSubj).error).toEqual([
+    expect(parse(detailedReqStrSchema, undefinedSubj).error).toStrictEqual([
       {
         code: PARSE_ERROR_CODE.invalidType,
         subject: undefinedSubj,
@@ -145,7 +145,7 @@ describe('Parse BASE schema with INVALID subject', () => {
     const numberSubj = 0
 
     expect(parse(detailedOptStrSchema, numberSubj).data).toBe(undefined)
-    expect(parse(detailedOptStrSchema, numberSubj).error).toEqual([
+    expect(parse(detailedOptStrSchema, numberSubj).error).toStrictEqual([
       {
         code: PARSE_ERROR_CODE.invalidType,
         subject: numberSubj,
@@ -183,6 +183,13 @@ describe('Parse OBJECT schema with VALID subject', () => {
       d: 1,
       e: true,
       f: false,
+
+      nullB: undefined,
+      undefinedB: undefined,
+      nullD: undefined,
+      undefinedD: undefined,
+      nullF: undefined,
+      undefinedF: undefined,
     }
 
     const subject = {
@@ -196,8 +203,8 @@ describe('Parse OBJECT schema with VALID subject', () => {
       extraKeyWhichShouldBeIgnored: 'x',
     }
 
-    expect(parse(schema, subject).data).toEqual(expectedSubject)
-    expect(parse(schema, subject).error).toEqual(undefined)
+    expect(parse(schema, subject).data).toStrictEqual(expectedSubject)
+    expect(parse(schema, subject).error).toStrictEqual(undefined)
   })
 
   it('parse: nested base deailed schema subject', () => {
@@ -278,6 +285,17 @@ describe('Parse OBJECT schema with VALID subject', () => {
       undefinedJDef: 'y',
       nullLDef: 0,
       undefinedLDef: 1,
+
+      nullB: undefined,
+      undefinedB: undefined,
+      nullD: undefined,
+      undefinedD: undefined,
+      nullF: undefined,
+      undefinedF: undefined,
+      nullJ: undefined,
+      undefinedJ: undefined,
+      nullL: undefined,
+      undefinedL: undefined,
     }
 
     const subject = {
@@ -314,8 +332,8 @@ describe('Parse OBJECT schema with VALID subject', () => {
       extraKeyWhichShouldBeIgnored: 'x',
     }
 
-    expect(parse(schema, subject).data).toEqual(expectedSubject)
-    expect(parse(schema, subject).error).toEqual(undefined)
+    expect(parse(schema, subject).data).toStrictEqual(expectedSubject)
+    expect(parse(schema, subject).error).toStrictEqual(undefined)
   })
 
   it('parse: nested array schema subject', () => {
@@ -332,10 +350,11 @@ describe('Parse OBJECT schema with VALID subject', () => {
       strArrOpt: null,
     }
 
-    expect(parse(schema, subject).data).toEqual({
+    expect(parse(schema, subject).data).toStrictEqual({
       strArrReq: subject.strArrReq,
+      strArrOpt: undefined,
     })
-    expect(parse(schema, subject).error).toEqual(undefined)
+    expect(parse(schema, subject).error).toStrictEqual(undefined)
   })
 
   it('parse: can be optional by itself', () => {
@@ -362,7 +381,7 @@ describe('Parse OBJECT schema with INVALID subject', () => {
     const undefinedSubj = undefined
 
     expect(parse(schema, undefinedSubj).data).toBe(undefined)
-    expect(parse(schema, undefinedSubj).error).toEqual([
+    expect(parse(schema, undefinedSubj).error).toStrictEqual([
       {
         code: PARSE_ERROR_CODE.invalidType,
         subject: undefinedSubj,
@@ -374,7 +393,7 @@ describe('Parse OBJECT schema with INVALID subject', () => {
     const nullSubj = null
 
     expect(parse(schema, nullSubj).data).toBe(undefined)
-    expect(parse(schema, nullSubj).error).toEqual([
+    expect(parse(schema, nullSubj).error).toStrictEqual([
       {
         code: PARSE_ERROR_CODE.invalidType,
         subject: nullSubj,
@@ -386,7 +405,7 @@ describe('Parse OBJECT schema with INVALID subject', () => {
     const regExpSubj = /^x/
 
     expect(parse(schema, regExpSubj).data).toBe(undefined)
-    expect(parse(schema, regExpSubj).error).toEqual([
+    expect(parse(schema, regExpSubj).error).toStrictEqual([
       {
         code: PARSE_ERROR_CODE.invalidType,
         subject: regExpSubj,
@@ -398,7 +417,7 @@ describe('Parse OBJECT schema with INVALID subject', () => {
     const arraySubj = [] as unknown
 
     expect(parse(schema, arraySubj).data).toBe(undefined)
-    expect(parse(schema, arraySubj).error).toEqual([
+    expect(parse(schema, arraySubj).error).toStrictEqual([
       {
         code: PARSE_ERROR_CODE.invalidType,
         subject: arraySubj,
@@ -410,7 +429,7 @@ describe('Parse OBJECT schema with INVALID subject', () => {
     const mapSubj = new Map()
 
     expect(parse(schema, mapSubj).data).toBe(undefined)
-    expect(parse(schema, mapSubj).error).toEqual([
+    expect(parse(schema, mapSubj).error).toStrictEqual([
       {
         code: PARSE_ERROR_CODE.invalidType,
         subject: mapSubj,
@@ -422,7 +441,7 @@ describe('Parse OBJECT schema with INVALID subject', () => {
     const setSubj = new Set()
 
     expect(parse(schema, setSubj).data).toBe(undefined)
-    expect(parse(schema, setSubj).error).toEqual([
+    expect(parse(schema, setSubj).error).toStrictEqual([
       {
         code: PARSE_ERROR_CODE.invalidType,
         subject: setSubj,
@@ -448,7 +467,7 @@ describe('Parse OBJECT schema with INVALID subject', () => {
     }
 
     expect(parse(schema, subject).data).toBe(undefined)
-    expect(parse(schema, subject).error).toEqual([
+    expect(parse(schema, subject).error).toStrictEqual([
       {
         code: PARSE_ERROR_CODE.invalidType,
         subject: subject[firstInvalidSubjKey],
@@ -526,7 +545,7 @@ describe('Parse OBJECT schema with INVALID subject', () => {
     }
 
     expect(parse(schema, subject).data).toBe(undefined)
-    expect(parse(schema, subject).error).toEqual([
+    expect(parse(schema, subject).error).toStrictEqual([
       {
         code: PARSE_ERROR_CODE.invalidType,
         subject: invalidSubject,
@@ -559,7 +578,7 @@ describe('Parse OBJECT schema with INVALID subject', () => {
     }
 
     expect(parse(schema, subject).data).toBe(undefined)
-    expect(parse(schema, subject).error).toEqual([
+    expect(parse(schema, subject).error).toStrictEqual([
       {
         code: PARSE_ERROR_CODE.invalidType,
         subject: invalidSubject,
@@ -579,7 +598,7 @@ describe('Parse ARRAY schema with VALID subject', () => {
 
     const stringSubj = ['x', 'y']
 
-    expect(parse(stringArrSchema, stringSubj).data).toEqual(stringSubj)
+    expect(parse(stringArrSchema, stringSubj).data).toStrictEqual(stringSubj)
     expect(parse(stringArrSchema, stringSubj).error).toBe(undefined)
 
     const numberArrSchema = {
@@ -589,7 +608,7 @@ describe('Parse ARRAY schema with VALID subject', () => {
 
     const numberSubj = [0, 1]
 
-    expect(parse(numberArrSchema, numberSubj).data).toEqual(numberSubj)
+    expect(parse(numberArrSchema, numberSubj).data).toStrictEqual(numberSubj)
     expect(parse(numberArrSchema, numberSubj).error).toBe(undefined)
 
     const booleanArrSchema = {
@@ -599,12 +618,13 @@ describe('Parse ARRAY schema with VALID subject', () => {
 
     const booleanSubj = [true, false]
 
-    expect(parse(booleanArrSchema, booleanSubj).data).toEqual(booleanSubj)
+    expect(parse(booleanArrSchema, booleanSubj).data).toStrictEqual(booleanSubj)
     expect(parse(booleanArrSchema, booleanSubj).error).toBe(undefined)
   })
 
   it('parse: optional base short schema subject', () => {
-    const arrWithNullable = [null, null, undefined, null] as unknown
+    const nullArr = [null, null, undefined, null] as unknown
+    const nullArrExp = [undefined, undefined, undefined, undefined]
 
     const optStrSchema = {
       type: 'array',
@@ -613,10 +633,10 @@ describe('Parse ARRAY schema with VALID subject', () => {
 
     const strSubject = ['x', 'y']
 
-    expect(parse(optStrSchema, strSubject).data).toEqual(strSubject)
+    expect(parse(optStrSchema, strSubject).data).toStrictEqual(strSubject)
     expect(parse(optStrSchema, strSubject).error).toBe(undefined)
-    expect(parse(optStrSchema, arrWithNullable).data).toEqual([])
-    expect(parse(optStrSchema, arrWithNullable).error).toBe(undefined)
+    expect(parse(optStrSchema, nullArr).data).toStrictEqual(nullArrExp)
+    expect(parse(optStrSchema, nullArr).error).toBe(undefined)
 
     const optNumSchema = {
       type: 'array',
@@ -625,10 +645,10 @@ describe('Parse ARRAY schema with VALID subject', () => {
 
     const numSubject = [0, 1, 2, 3, 4]
 
-    expect(parse(optNumSchema, numSubject).data).toEqual(numSubject)
+    expect(parse(optNumSchema, numSubject).data).toStrictEqual(numSubject)
     expect(parse(optNumSchema, numSubject).error).toBe(undefined)
-    expect(parse(optNumSchema, arrWithNullable).data).toEqual([])
-    expect(parse(optNumSchema, arrWithNullable).error).toBe(undefined)
+    expect(parse(optNumSchema, nullArr).data).toStrictEqual(nullArrExp)
+    expect(parse(optNumSchema, nullArr).error).toBe(undefined)
 
     const optBoolSchema = {
       type: 'array',
@@ -637,10 +657,10 @@ describe('Parse ARRAY schema with VALID subject', () => {
 
     const boolSubject = [true, true, false, true]
 
-    expect(parse(optBoolSchema, boolSubject).data).toEqual(boolSubject)
+    expect(parse(optBoolSchema, boolSubject).data).toStrictEqual(boolSubject)
     expect(parse(optBoolSchema, boolSubject).error).toBe(undefined)
-    expect(parse(optBoolSchema, arrWithNullable).data).toEqual([])
-    expect(parse(optBoolSchema, arrWithNullable).error).toBe(undefined)
+    expect(parse(optBoolSchema, nullArr).data).toStrictEqual(nullArrExp)
+    expect(parse(optBoolSchema, nullArr).error).toBe(undefined)
   })
 
   it('parse: required base detailed schema subject', () => {
@@ -651,7 +671,7 @@ describe('Parse ARRAY schema with VALID subject', () => {
 
     const strSubj = ['x', 'y', 'x', 'y']
 
-    expect(parse(strSchema, strSubj).data).toEqual(strSubj)
+    expect(parse(strSchema, strSubj).data).toStrictEqual(strSubj)
     expect(parse(strSchema, strSubj).error).toBe(undefined)
 
     const numSchema = {
@@ -661,7 +681,7 @@ describe('Parse ARRAY schema with VALID subject', () => {
 
     const numSubj = [0, 1, 2, 3, 4]
 
-    expect(parse(numSchema, numSubj).data).toEqual(numSubj)
+    expect(parse(numSchema, numSubj).data).toStrictEqual(numSubj)
     expect(parse(numSchema, numSubj).error).toBe(undefined)
 
     const boolSchema = {
@@ -671,7 +691,7 @@ describe('Parse ARRAY schema with VALID subject', () => {
 
     const boolSubj = [true, true, false, true]
 
-    expect(parse(boolSchema, boolSubj).data).toEqual(boolSubj)
+    expect(parse(boolSchema, boolSubj).data).toStrictEqual(boolSubj)
     expect(parse(boolSchema, boolSubj).error).toBe(undefined)
 
     const strUnionSchema = {
@@ -684,7 +704,7 @@ describe('Parse ARRAY schema with VALID subject', () => {
 
     const strUnionSubj = ['x', 'y', 'x', 'y']
 
-    expect(parse(strUnionSchema, strUnionSubj).data).toEqual(strUnionSubj)
+    expect(parse(strUnionSchema, strUnionSubj).data).toStrictEqual(strUnionSubj)
     expect(parse(strUnionSchema, strUnionSubj).error).toBe(undefined)
 
     const numUnionSchema = {
@@ -697,12 +717,13 @@ describe('Parse ARRAY schema with VALID subject', () => {
 
     const numUnionSubj = [0, 1, 0, 1]
 
-    expect(parse(numUnionSchema, numUnionSubj).data).toEqual(numUnionSubj)
+    expect(parse(numUnionSchema, numUnionSubj).data).toStrictEqual(numUnionSubj)
     expect(parse(numUnionSchema, numUnionSubj).error).toBe(undefined)
   })
 
   it('parse: optional base detailed schema subject', () => {
-    const arrWithNullable = [null, null, undefined, null] as unknown
+    const nullArr = [null, null, undefined, null] as unknown
+    const nullArrExp = [undefined, undefined, undefined, undefined]
 
     const strSchema = {
       type: 'array',
@@ -711,10 +732,10 @@ describe('Parse ARRAY schema with VALID subject', () => {
 
     const strSubj = ['x', 'y', 'x', 'y']
 
-    expect(parse(strSchema, strSubj).data).toEqual(strSubj)
+    expect(parse(strSchema, strSubj).data).toStrictEqual(strSubj)
     expect(parse(strSchema, strSubj).error).toBe(undefined)
-    expect(parse(strSchema, arrWithNullable).data).toEqual([])
-    expect(parse(strSchema, arrWithNullable).error).toBe(undefined)
+    expect(parse(strSchema, nullArr).data).toStrictEqual(nullArrExp)
+    expect(parse(strSchema, nullArr).error).toBe(undefined)
 
     const numSchema = {
       type: 'array',
@@ -723,10 +744,10 @@ describe('Parse ARRAY schema with VALID subject', () => {
 
     const numSubj = [0, 1, 2, 3, 4]
 
-    expect(parse(numSchema, numSubj).data).toEqual(numSubj)
+    expect(parse(numSchema, numSubj).data).toStrictEqual(numSubj)
     expect(parse(numSchema, numSubj).error).toBe(undefined)
-    expect(parse(numSchema, arrWithNullable).data).toEqual([])
-    expect(parse(numSchema, arrWithNullable).error).toBe(undefined)
+    expect(parse(numSchema, nullArr).data).toStrictEqual(nullArrExp)
+    expect(parse(numSchema, nullArr).error).toBe(undefined)
 
     const boolSchema = {
       type: 'array',
@@ -735,10 +756,10 @@ describe('Parse ARRAY schema with VALID subject', () => {
 
     const boolSubj = [true, true, false, true]
 
-    expect(parse(boolSchema, boolSubj).data).toEqual(boolSubj)
+    expect(parse(boolSchema, boolSubj).data).toStrictEqual(boolSubj)
     expect(parse(boolSchema, boolSubj).error).toBe(undefined)
-    expect(parse(boolSchema, arrWithNullable).data).toEqual([])
-    expect(parse(boolSchema, arrWithNullable).error).toBe(undefined)
+    expect(parse(boolSchema, nullArr).data).toStrictEqual(nullArrExp)
+    expect(parse(boolSchema, nullArr).error).toBe(undefined)
 
     const strUnionSchema = {
       type: 'array',
@@ -751,10 +772,10 @@ describe('Parse ARRAY schema with VALID subject', () => {
 
     const strUnionSubj = ['x', 'y', 'x', 'y']
 
-    expect(parse(strUnionSchema, strUnionSubj).data).toEqual(strUnionSubj)
+    expect(parse(strUnionSchema, strUnionSubj).data).toStrictEqual(strUnionSubj)
     expect(parse(strUnionSchema, strUnionSubj).error).toBe(undefined)
-    expect(parse(strUnionSchema, arrWithNullable).data).toEqual([])
-    expect(parse(strUnionSchema, arrWithNullable).error).toBe(undefined)
+    expect(parse(strUnionSchema, nullArr).data).toStrictEqual(nullArrExp)
+    expect(parse(strUnionSchema, nullArr).error).toBe(undefined)
 
     const numUnionSchema = {
       type: 'array',
@@ -767,10 +788,10 @@ describe('Parse ARRAY schema with VALID subject', () => {
 
     const numUnionSubj = [0, 1, 0, 1]
 
-    expect(parse(numUnionSchema, numUnionSubj).data).toEqual(numUnionSubj)
+    expect(parse(numUnionSchema, numUnionSubj).data).toStrictEqual(numUnionSubj)
     expect(parse(numUnionSchema, numUnionSubj).error).toBe(undefined)
-    expect(parse(numUnionSchema, arrWithNullable).data).toEqual([])
-    expect(parse(numUnionSchema, arrWithNullable).error).toBe(undefined)
+    expect(parse(numUnionSchema, nullArr).data).toStrictEqual(nullArrExp)
+    expect(parse(numUnionSchema, nullArr).error).toBe(undefined)
   })
 
   it('parse: can be optional by itself', () => {
@@ -797,7 +818,7 @@ describe('Parse ARRAY schema with INVALID subject', () => {
     const undefinedSubj = undefined
 
     expect(parse(schema, undefinedSubj).data).toBe(undefined)
-    expect(parse(schema, undefinedSubj).error).toEqual([
+    expect(parse(schema, undefinedSubj).error).toStrictEqual([
       {
         code: PARSE_ERROR_CODE.invalidType,
         subject: undefinedSubj,
@@ -809,7 +830,7 @@ describe('Parse ARRAY schema with INVALID subject', () => {
     const nullSubj = null
 
     expect(parse(schema, nullSubj).data).toBe(undefined)
-    expect(parse(schema, nullSubj).error).toEqual([
+    expect(parse(schema, nullSubj).error).toStrictEqual([
       {
         code: PARSE_ERROR_CODE.invalidType,
         subject: nullSubj,
@@ -821,7 +842,7 @@ describe('Parse ARRAY schema with INVALID subject', () => {
     const stringSubj = 'x'
 
     expect(parse(schema, stringSubj).data).toBe(undefined)
-    expect(parse(schema, stringSubj).error).toEqual([
+    expect(parse(schema, stringSubj).error).toStrictEqual([
       {
         code: PARSE_ERROR_CODE.invalidType,
         subject: stringSubj,
@@ -841,7 +862,7 @@ describe('Parse ARRAY schema with INVALID subject', () => {
     const strSubject = 'x'
 
     expect(parse(schema, strSubject).data).toBe(undefined)
-    expect(parse(schema, strSubject).error).toEqual([
+    expect(parse(schema, strSubject).error).toStrictEqual([
       {
         code: PARSE_ERROR_CODE.invalidType,
         subject: strSubject,
@@ -873,7 +894,7 @@ describe('Parse ARRAY schema with INVALID subject', () => {
     subject[secondInvalidIndex] = invalidSubject
 
     expect(parse(schema, subject).data).toBe(undefined)
-    expect(parse(schema, subject).error).toEqual([
+    expect(parse(schema, subject).error).toStrictEqual([
       {
         code: PARSE_ERROR_CODE.invalidType,
         subject: invalidSubject,
@@ -947,7 +968,7 @@ describe('Parse ARRAY schema with INVALID subject', () => {
     ]
 
     expect(parse(schema, subject).data).toBe(undefined)
-    expect(parse(schema, subject).error).toEqual([
+    expect(parse(schema, subject).error).toStrictEqual([
       {
         code: PARSE_ERROR_CODE.invalidType,
         subject: invalidSubjForStr,

--- a/src/test/types/compound-schema-types.test.ts
+++ b/src/test/types/compound-schema-types.test.ts
@@ -246,57 +246,62 @@ describe('Construct ArraySchema subject type PARSED', () => {
     )
   })
 
-  it('Con_ArraySchema_SubjT_P<T>: should ignore nested BaseSchema optionality', () => {
-    check<string[]>(
+  it('Con_ArraySchema_SubjT_P<T>: must not ignore nested BaseSchema optionality', () => {
+    check<Array<string | undefined>>(
       unknownX as Con_ArraySchema_SubjT_P<{ type: 'array'; of: 'string?' }>
     )
-    check<string[]>(
-      // @ts-expect-error 'number[]' is not assignable to parameter of type 'string[]'
-      unknownX as Con_ArraySchema_SubjT_P<{ type: 'array'; of: 'number?' }>
+    check<Array<string>>(
+      // @ts-expect-error '(string | undefined)[]' is not assignable to parameter of type 'string[]'
+      unknownX as Con_ArraySchema_SubjT_P<{ type: 'array'; of: 'string?' }>
     )
-    check<string[]>(
-      unknownX as Con_ArraySchema_SubjT_P<{
-        type: 'array'
-        of: { type: 'string'; optional: true }
-      }>
-    )
-    check<string[]>(
-      // @ts-expect-error 'number[]' is not assignable to parameter of type 'string[]'
-      unknownX as Con_ArraySchema_SubjT_P<{
-        type: 'array'
-        of: { type: 'number'; optional: true }
-      }>
+    check<Array<number | undefined>>(
+      // @ts-expect-error '(string | undefined)[]' is not '(number | undefined)[]'
+      unknownX as Con_ArraySchema_SubjT_P<{ type: 'array'; of: 'string?' }>
     )
   })
 
-  it('Con_ArraySchema_SubjT_P<T>: should ignore nested ArraySchema optionality', () => {
-    check<string[][]>(
+  it('Con_ArraySchema_SubjT_P<T>: must not ignore nested ArraySchema optionality', () => {
+    check<Array<string[] | undefined>>(
       unknownX as Con_ArraySchema_SubjT_P<{
         type: 'array'
         of: { type: 'array'; of: 'string'; optional: true }
       }>
     )
-    check<string[][]>(
-      // @ts-expect-error 'number[][]' is not assignable to parameter of type 'string[][]'
+    check<Array<string[]>>(
+      // @ts-expect-error '(string[] | undefined)[]' is not assignable to parameter of type 'string[][]'
       unknownX as Con_ArraySchema_SubjT_P<{
         type: 'array'
-        of: { type: 'array'; of: 'number'; optional: true }
+        of: { type: 'array'; of: 'string'; optional: true }
+      }>
+    )
+    check<Array<number[] | undefined>>(
+      // @ts-expect-error '(string[] | undefined)[]' is not '(number[] | undefined)[]'
+      unknownX as Con_ArraySchema_SubjT_P<{
+        type: 'array'
+        of: { type: 'array'; of: 'string'; optional: true }
       }>
     )
   })
 
-  it('Con_ArraySchema_SubjT_P<T>: should ignore nested ObjectSchema optionality', () => {
-    check<Array<{ x: string }>>(
+  it('Con_ArraySchema_SubjT_P<T>: must not ignore ObjectSchema optionality', () => {
+    check<Array<{ x: string } | undefined>>(
       unknownX as Con_ArraySchema_SubjT_P<{
         type: 'array'
         of: { type: 'object'; of: { x: 'string' }; optional: true }
       }>
     )
     check<Array<{ x: string }>>(
-      // @ts-expect-error 'number' is not assignable to type 'string'
+      // @ts-expect-error '({ x: string; } | undefined)[]' is not '{ x: string; }[]'
       unknownX as Con_ArraySchema_SubjT_P<{
         type: 'array'
-        of: { type: 'object'; of: { x: 'number' }; optional: true }
+        of: { type: 'object'; of: { x: 'string' }; optional: true }
+      }>
+    )
+    check<Array<{ x: number } | undefined>>(
+      // @ts-expect-error '({ x: string; } | undefined)[]' is not '({ x: number; } | undefined)[]'
+      unknownX as Con_ArraySchema_SubjT_P<{
+        type: 'array'
+        of: { type: 'object'; of: { x: 'string' }; optional: true }
       }>
     )
   })
@@ -580,8 +585,8 @@ describe('Construct ObjectSchema subject type PARSED', () => {
     )
   })
 
-  it('Con_ObjectSchema_SubjT_P<T>: nested ArraySchema should ignore its nested schema optionality', () => {
-    check<{ x: string[]; y: number[] }>(
+  it('Con_ObjectSchema_SubjT_P<T>: nested ArraySchema must not ignore its nested schema optionality', () => {
+    check<{ x: Array<string | undefined>; y: Array<number | undefined> }>(
       unknownX as Con_ObjectSchema_SubjT_P<{
         type: 'object'
         of: {
@@ -590,14 +595,12 @@ describe('Construct ObjectSchema subject type PARSED', () => {
         }
       }>
     )
-
-    check<{ x: string[]; y: number[] }>(
-      // @ts-expect-error 'string' is not assignable to type 'number'
+    check<{ x: Array<string | undefined>; y: Array<number | undefined> }>(
       unknownX as Con_ObjectSchema_SubjT_P<{
         type: 'object'
         of: {
           x: { type: 'array'; of: 'string?' }
-          y: { type: 'array'; of: 'string?' }
+          y: { type: 'array'; of: 'number?' }
         }
       }>
     )
@@ -910,7 +913,7 @@ describe('Construct ObjectSchema subject type VALIDATED', () => {
   })
 })
 
-describe('Construct Schema subject type PARSED/VALIDATED diff', () => {
+describe('Construct Schema subject type PARSED/VALIDATED differences', () => {
   it('BaseSchema default property subject type diff depending on the SubjT_P/Subj_V context', () => {
     const stringSchemaWithDefaultProperty = {
       type: 'string',
@@ -927,24 +930,6 @@ describe('Construct Schema subject type PARSED/VALIDATED diff', () => {
     check<string>(
       // @ts-expect-error 'string | undefined' is not assignable to parameter of type 'string'
       unknownX as Con_Schema_SubjT_V<typeof stringSchemaWithDefaultProperty>
-    )
-  })
-
-  it('ArraySchema optional property subject type diff depending on the SubjT_P/Subj_V context', () => {
-    const arraySchemaWithOptionalNestedSchema = {
-      type: 'array',
-      of: { type: 'string', optional: true },
-    } as const satisfies Schema
-
-    check<string[]>(
-      unknownX as Con_Schema_SubjT_P<typeof arraySchemaWithOptionalNestedSchema>
-    )
-    check<(string | undefined)[]>(
-      unknownX as Con_Schema_SubjT_V<typeof arraySchemaWithOptionalNestedSchema>
-    )
-    check<string[]>(
-      // @ts-expect-error '(string | undefined)[]' is not assignable to parameter of type 'string[]'
-      unknownX as Con_Schema_SubjT_V<typeof arraySchemaWithOptionalNestedSchema>
     )
   })
 
@@ -1417,11 +1402,11 @@ describe('Construct Schema subject type in the context of deeply nested schemas'
         arraySchema: {
           required: {
             requiredString: string[]
-            optionalString: string[]
+            optionalString: (string | undefined)[]
           }
           optional: {
             requiredString?: string[]
-            optionalString?: string[]
+            optionalString?: (string | undefined)[]
           }
         }
       }
@@ -1454,16 +1439,16 @@ describe('Construct Schema subject type in the context of deeply nested schemas'
           required: {
             requiredString: string[]
             requiredStringBranded: Array<string & { __K: 'V' }>
-            optionalString: string[]
-            optionalStringBranded: Array<string & { __K: 'V' }>
+            optionalString: (undefined | string)[]
+            optionalStringBranded: Array<(string & { __K: 'V' }) | undefined>
             optionalStringDefault: string[]
             optionalStringDefaultBranded: Array<string & { __K: 'V' }>
           }
           optional?: {
             requiredString?: string[]
             requiredStringBranded?: Array<string & { __K: 'V' }>
-            optionalString?: string[]
-            optionalStringBranded?: Array<string & { __K: 'V' }>
+            optionalString?: (string | undefined)[]
+            optionalStringBranded?: Array<(string & { __K: 'V' }) | undefined>
             optionalStringDefault?: string[]
             optionalStringDefaultBranded?: Array<string & { __K: 'V' }>
           }

--- a/src/test/x-closure.test.ts
+++ b/src/test/x-closure.test.ts
@@ -348,6 +348,17 @@ describe('X closure statically defined schema VALID', () => {
     expect(strOpt.validate(undefined).error).toBe(undefined)
   })
 
+  it('x: compound array required schema inner optional parse/validate', () => {
+    const str = x({ type: 'array', of: 'string?' })
+    const subj = [undefined, 'x', undefined]
+
+    expect(str.parse(subj).data).toStrictEqual(subj)
+    expect(str.parse(subj).error).toBe(undefined)
+
+    expect(str.validate(subj).data).toStrictEqual(subj)
+    expect(str.validate(subj).error).toBe(undefined)
+  })
+
   it('x: compound object schema required/optional parse/validate', () => {
     const str = x({ type: 'object', of: { x: 'string' } })
     const subj = { x: 'x' }

--- a/src/types/compound-schema-types.ts
+++ b/src/types/compound-schema-types.ts
@@ -63,12 +63,6 @@ export type ExtWith_CompoundSchemaOptionality<
   U,
 > = T extends { optional: true } ? U | undefined : U
 
-// TODO: should work as expected only if we add `& {}`
-//        which is currently forbidden by our linter
-export type Prettify_ObjectSchema_SubjT<T> = {
-  [k in keyof T]: T[k]
-}
-
 /* Construct ArraySchema subject type */
 
 export type Con_ArraySchema_SubjT_P<T extends ArraySchema> =
@@ -76,11 +70,11 @@ export type Con_ArraySchema_SubjT_P<T extends ArraySchema> =
     T,
     T extends { of: infer U }
       ? U extends BaseSchema
-        ? Array<NonNullable<Con_BaseSchema_SubjT_P<U>>>
+        ? Array<Con_BaseSchema_SubjT_P<U>>
         : U extends ArraySchema
-          ? Array<NonNullable<Con_ArraySchema_SubjT_P<U>>>
+          ? Array<Con_ArraySchema_SubjT_P<U>>
           : U extends ObjectSchema
-            ? Array<NonNullable<Con_ObjectSchema_SubjT_P<U>>>
+            ? Array<Con_ObjectSchema_SubjT_P<U>>
             : never
       : never
   >


### PR DESCRIPTION
fixes #1 

- Adjust general schema parser
- Use `toStrictEqual` instead of `toEqual` jest method in general schema parser tests
- Adjust contributing/readme docs according to the new change