### PR TITLE
Remove redundant error codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ const staticArray = {
 const programmaticArray = array(string())
 ```
 
-## Validate/parse error shape
+## Validate/parse InvalidSubject error shape
 
 Nested schema example. Subject `0` is invalid, should be a `string`:
 
@@ -333,6 +333,13 @@ The `result.error` will be:
   }
 ]
 ```
+
+If the `error` is present it's always an array which has at least one entry. Each entry has the following properties:
+
+- `code` – could be `INVALID_TYPE` if schema subject or schema default value is not satisfies schema type requirement. Another code `INVALID_RANGE` which is about `min/max` and `minLength/maxLength` schema requirements
+- `schema` – the particular chunk of the `schema` where invalid subject value is found
+- `subject` – the particular chunk of the validated subject where invalid value is found
+- `path` – the path to error subject chunk from the root of the evaluated subject. Strings is keys and numbers are the array indexes
 
 ## Parse/validate differences
 

--- a/src/base-schema-parser.ts
+++ b/src/base-schema-parser.ts
@@ -1,25 +1,26 @@
 import { error, data } from './utils/fp'
-import { PARSE_ERROR_CODE } from './error'
+import { ERROR_CODE } from './error'
 
 import type { EitherError } from './utils/fp'
-import type { BD_String, BD_Number } from './types/base-detailed-schema-types'
 import type {
   BaseSchema,
   Con_Schema_SubjT_P,
 } from './types/compound-schema-types'
-import type { BaseSchemaParseError } from './error'
+import type { InvalidSubject, ErrorPath } from './error'
 
 export type BaseSchemaSubjectType = string | number | boolean | undefined
 
 export function parseBaseSchemaSubject<T extends BaseSchema>(
+  this: ErrorPath | void,
   schema: T,
   schemaSubject: unknown
-): EitherError<BaseSchemaParseError, Con_Schema_SubjT_P<T>>
+): EitherError<InvalidSubject, Con_Schema_SubjT_P<T>>
 
 export function parseBaseSchemaSubject(
+  this: ErrorPath | void,
   schema: BaseSchema,
   subject: unknown
-): EitherError<BaseSchemaParseError, BaseSchemaSubjectType> {
+): EitherError<InvalidSubject, BaseSchemaSubjectType> {
   if (typeof schema === 'string') {
     switch (schema) {
       case 'string?':
@@ -32,7 +33,8 @@ export function parseBaseSchemaSubject(
           }
 
           return error({
-            code: PARSE_ERROR_CODE.invalidType,
+            code: ERROR_CODE.invalidType,
+            path: this || [],
             schema,
             subject,
           })
@@ -51,23 +53,17 @@ export function parseBaseSchemaSubject(
           }
 
           return error({
-            code: PARSE_ERROR_CODE.invalidType,
+            code: ERROR_CODE.invalidType,
+            path: this || [],
             schema,
             subject,
           })
         }
 
-        if (Number.isNaN(subject)) {
+        if (Number.isNaN(subject) || Number.isFinite(subject) === false) {
           return error({
-            code: PARSE_ERROR_CODE.NaN,
-            schema,
-            subject,
-          })
-        }
-
-        if (Number.isFinite(subject) === false) {
-          return error({
-            code: PARSE_ERROR_CODE.infinity,
+            code: ERROR_CODE.invalidType,
+            path: this || [],
             schema,
             subject,
           })
@@ -86,7 +82,8 @@ export function parseBaseSchemaSubject(
           }
 
           return error({
-            code: PARSE_ERROR_CODE.invalidType,
+            code: ERROR_CODE.invalidType,
+            path: this || [],
             schema,
             subject,
           })
@@ -97,263 +94,158 @@ export function parseBaseSchemaSubject(
     }
   }
 
+  const updatedSubject =
+    typeof schema.default !== undefined &&
+    schema.optional &&
+    (subject === null || subject === undefined)
+      ? schema.default
+      : subject
+
+  if (schema.optional) {
+    if (updatedSubject === null || updatedSubject === undefined) {
+      return data(undefined)
+    }
+  }
+
   switch (schema.type) {
     case 'string': {
-      if (typeof subject !== 'string') {
-        if (subject === undefined || subject === null) {
-          if (schema.optional) {
-            if (typeof schema.default === 'string') {
-              const rangeError = getStringRangeError(
-                schema,
-                schema.default,
-                true
-              )
-
-              if (rangeError) {
-                return error(rangeError)
-              }
-
-              return data(schema.default)
-            }
-
-            return data(undefined)
-          }
-        }
-
+      if (typeof updatedSubject !== 'string') {
         return error({
-          code: PARSE_ERROR_CODE.invalidType,
+          code: ERROR_CODE.invalidType,
+          subject: updatedSubject,
+          path: this || [],
           schema,
-          subject,
         })
       }
 
-      const rangeError = getStringRangeError(schema, subject, false)
-
-      if (rangeError) {
-        return error(rangeError)
+      if (typeof schema.minLength === 'number') {
+        if (updatedSubject.length < schema.minLength) {
+          return error({
+            code: ERROR_CODE.invalidRange,
+            subject: updatedSubject,
+            path: this || [],
+            schema,
+          })
+        }
       }
 
-      return data(subject)
+      if (typeof schema.maxLength === 'number') {
+        if (updatedSubject.length > schema.maxLength) {
+          return error({
+            code: ERROR_CODE.invalidRange,
+            subject: updatedSubject,
+            path: this || [],
+            schema,
+          })
+        }
+      }
+
+      return data(updatedSubject)
     }
 
     case 'number': {
-      if (typeof subject !== 'number') {
-        if (subject === undefined || subject === null) {
-          if (schema.optional) {
-            if (typeof schema.default === 'number') {
-              const rangeError = getNumberRangeError(
-                schema,
-                schema.default,
-                true
-              )
+      if (typeof updatedSubject !== 'number') {
+        return error({
+          code: ERROR_CODE.invalidType,
+          subject: updatedSubject,
+          path: this || [],
+          schema,
+        })
+      }
 
-              if (rangeError) {
-                return error(rangeError)
-              }
+      if (Number.isFinite(updatedSubject) === false) {
+        return error({
+          code: ERROR_CODE.invalidType,
+          subject: updatedSubject,
+          path: this || [],
+          schema,
+        })
+      }
 
-              return data(schema.default)
-            }
-
-            return data(undefined)
-          }
+      if (typeof schema.min === 'number') {
+        if (updatedSubject < schema.min) {
+          return error({
+            code: ERROR_CODE.invalidRange,
+            subject: updatedSubject,
+            path: this || [],
+            schema,
+          })
         }
-
-        return error({
-          code: PARSE_ERROR_CODE.invalidType,
-          schema,
-          subject,
-        })
       }
 
-      if (Number.isNaN(subject)) {
-        return error({
-          code: PARSE_ERROR_CODE.NaN,
-          schema,
-          subject,
-        })
+      if (typeof schema.max === 'number') {
+        if (updatedSubject > schema.max) {
+          return error({
+            code: ERROR_CODE.invalidRange,
+            subject: updatedSubject,
+            path: this || [],
+            schema,
+          })
+        }
       }
 
-      if (Number.isFinite(subject) === false) {
-        return error({
-          code: PARSE_ERROR_CODE.infinity,
-          schema,
-          subject,
-        })
-      }
-
-      const rangeError = getNumberRangeError(schema, subject, false)
-
-      if (rangeError) {
-        return error(rangeError)
-      }
-
-      return data(subject)
+      return data(updatedSubject)
     }
 
     case 'boolean': {
-      if (typeof subject !== 'boolean') {
-        if (subject === undefined || subject === null) {
-          if (schema.optional) {
-            if (typeof schema.default === 'boolean') {
-              return data(schema.default)
-            }
-
-            return data(undefined)
-          }
-        }
-
+      if (typeof updatedSubject !== 'boolean') {
         return error({
-          code: PARSE_ERROR_CODE.invalidType,
+          code: ERROR_CODE.invalidType,
+          subject: updatedSubject,
+          path: this || [],
           schema,
-          subject,
         })
       }
 
-      return data(subject)
+      return data(updatedSubject)
     }
 
     case 'stringUnion': {
-      if (typeof subject !== 'string') {
-        if (subject === undefined || subject === null) {
-          if (schema.optional) {
-            if (typeof schema.default === 'string') {
-              const unionSet = new Set(schema.of)
-
-              if (unionSet.has(schema.default) === false) {
-                return error({
-                  code: PARSE_ERROR_CODE.schemaDefaultNotInUnion,
-                  subject: schema.default,
-                  schema,
-                })
-              }
-
-              return data(schema.default)
-            }
-
-            return data(undefined)
-          }
-        }
-
+      if (typeof updatedSubject !== 'string') {
         return error({
-          code: PARSE_ERROR_CODE.invalidType,
+          code: ERROR_CODE.invalidType,
+          subject: updatedSubject,
+          path: this || [],
           schema,
-          subject,
         })
       }
 
       const unionSet = new Set(schema.of)
 
-      if (unionSet.has(subject) === false) {
+      if (unionSet.has(updatedSubject) === false) {
         return error({
-          code: PARSE_ERROR_CODE.notInUnion,
+          code: ERROR_CODE.invalidType,
+          subject: updatedSubject,
+          path: this || [],
           schema,
-          subject,
         })
       }
 
-      return data(subject)
+      return data(updatedSubject)
     }
 
     case 'numberUnion': {
-      if (typeof subject !== 'number') {
-        if (subject === undefined || subject === null) {
-          if (schema.optional) {
-            if (typeof schema.default === 'number') {
-              const unionSet = new Set(schema.of)
-
-              if (unionSet.has(schema.default) === false) {
-                return error({
-                  code: PARSE_ERROR_CODE.schemaDefaultNotInUnion,
-                  subject: schema.default,
-                  schema,
-                })
-              }
-
-              return data(schema.default)
-            }
-
-            return data(undefined)
-          }
-        }
-
+      if (typeof updatedSubject !== 'number') {
         return error({
-          code: PARSE_ERROR_CODE.invalidType,
+          code: ERROR_CODE.invalidType,
+          subject: updatedSubject,
+          path: this || [],
           schema,
-          subject,
         })
       }
 
       const unionSet = new Set(schema.of)
 
-      if (unionSet.has(subject) === false) {
+      if (unionSet.has(updatedSubject) === false) {
         return error({
-          code: PARSE_ERROR_CODE.notInUnion,
+          code: ERROR_CODE.invalidType,
+          subject: updatedSubject,
+          path: this || [],
           schema,
-          subject,
         })
       }
 
-      return data(subject)
-    }
-  }
-}
-
-function getStringRangeError(
-  schema: BD_String,
-  subject: string,
-  isSubjectFromSchemaDefault: boolean
-): BaseSchemaParseError | undefined {
-  if (typeof schema.minLength === 'number') {
-    if (subject.length < schema.minLength) {
-      return {
-        code: isSubjectFromSchemaDefault
-          ? PARSE_ERROR_CODE.schemaDefaultMinRange
-          : PARSE_ERROR_CODE.minRange,
-        schema,
-        subject,
-      }
-    }
-  }
-
-  if (typeof schema.maxLength === 'number') {
-    if (subject.length > schema.maxLength) {
-      return {
-        code: isSubjectFromSchemaDefault
-          ? PARSE_ERROR_CODE.schemaDefaultMaxRange
-          : PARSE_ERROR_CODE.maxRange,
-        schema,
-        subject,
-      }
-    }
-  }
-}
-
-function getNumberRangeError(
-  schema: BD_Number,
-  subject: number,
-  isSubjectFromSchemaDefault: boolean
-): BaseSchemaParseError | undefined {
-  if (typeof schema.min === 'number') {
-    if (subject < schema.min) {
-      return {
-        code: isSubjectFromSchemaDefault
-          ? PARSE_ERROR_CODE.schemaDefaultMinRange
-          : PARSE_ERROR_CODE.minRange,
-        schema,
-        subject,
-      }
-    }
-  }
-
-  if (typeof schema.max === 'number') {
-    if (subject > schema.max) {
-      return {
-        code: isSubjectFromSchemaDefault
-          ? PARSE_ERROR_CODE.schemaDefaultMaxRange
-          : PARSE_ERROR_CODE.maxRange,
-        schema,
-        subject,
-      }
+      return data(updatedSubject)
     }
   }
 }

--- a/src/base-schema-parser.ts
+++ b/src/base-schema-parser.ts
@@ -60,7 +60,7 @@ export function parseBaseSchemaSubject(
           })
         }
 
-        if (Number.isNaN(subject) || Number.isFinite(subject) === false) {
+        if (Number.isFinite(subject) === false) {
           return error({
             code: ERROR_CODE.invalidType,
             path: this || [],

--- a/src/base-schema-validator.ts
+++ b/src/base-schema-validator.ts
@@ -1,24 +1,26 @@
 import { error, data } from './utils/fp'
-import { VALIDATE_ERROR_CODE } from './error'
+import { ERROR_CODE } from './error'
 
 import type { EitherError } from './utils/fp'
 import type {
   BaseSchema,
   Con_Schema_SubjT_V,
 } from './types/compound-schema-types'
-import type { BaseSchemaValidateError } from './error'
+import type { InvalidSubject, ErrorPath } from './error'
 
 export type BaseSchemaSubjectType = string | number | boolean | undefined
 
 export function validateBaseSchemaSubject<T extends BaseSchema>(
+  this: ErrorPath | void,
   schema: T,
   schemaSubject: unknown
-): EitherError<BaseSchemaValidateError, Con_Schema_SubjT_V<T>>
+): EitherError<InvalidSubject, Con_Schema_SubjT_V<T>>
 
 export function validateBaseSchemaSubject(
+  this: ErrorPath | void,
   schema: BaseSchema,
   subject: unknown
-): EitherError<BaseSchemaValidateError, BaseSchemaSubjectType> {
+): EitherError<InvalidSubject, BaseSchemaSubjectType> {
   if (typeof schema === 'string') {
     switch (schema) {
       case 'string?':
@@ -29,7 +31,8 @@ export function validateBaseSchemaSubject(
           }
 
           return error({
-            code: VALIDATE_ERROR_CODE.invalidType,
+            code: ERROR_CODE.invalidType,
+            path: this || [],
             schema,
             subject,
           })
@@ -46,15 +49,8 @@ export function validateBaseSchemaSubject(
           }
 
           return error({
-            code: VALIDATE_ERROR_CODE.invalidType,
-            schema,
-            subject,
-          })
-        }
-
-        if (Number.isNaN(subject)) {
-          return error({
-            code: VALIDATE_ERROR_CODE.NaN,
+            code: ERROR_CODE.invalidType,
+            path: this || [],
             schema,
             subject,
           })
@@ -62,7 +58,8 @@ export function validateBaseSchemaSubject(
 
         if (Number.isFinite(subject) === false) {
           return error({
-            code: VALIDATE_ERROR_CODE.infinity,
+            code: ERROR_CODE.invalidType,
+            path: this || [],
             schema,
             subject,
           })
@@ -79,7 +76,8 @@ export function validateBaseSchemaSubject(
           }
 
           return error({
-            code: VALIDATE_ERROR_CODE.invalidType,
+            code: ERROR_CODE.invalidType,
+            path: this || [],
             schema,
             subject,
           })
@@ -98,7 +96,8 @@ export function validateBaseSchemaSubject(
         }
 
         return error({
-          code: VALIDATE_ERROR_CODE.invalidType,
+          code: ERROR_CODE.invalidType,
+          path: this || [],
           schema,
           subject,
         })
@@ -107,7 +106,8 @@ export function validateBaseSchemaSubject(
       if (typeof schema.minLength === 'number') {
         if (subject.length < schema.minLength) {
           return error({
-            code: VALIDATE_ERROR_CODE.minRange,
+            code: ERROR_CODE.invalidRange,
+            path: this || [],
             schema,
             subject,
           })
@@ -117,7 +117,8 @@ export function validateBaseSchemaSubject(
       if (typeof schema.maxLength === 'number') {
         if (subject.length > schema.maxLength) {
           return error({
-            code: VALIDATE_ERROR_CODE.maxRange,
+            code: ERROR_CODE.invalidRange,
+            path: this || [],
             schema,
             subject,
           })
@@ -134,15 +135,8 @@ export function validateBaseSchemaSubject(
         }
 
         return error({
-          code: VALIDATE_ERROR_CODE.invalidType,
-          schema,
-          subject,
-        })
-      }
-
-      if (Number.isNaN(subject)) {
-        return error({
-          code: VALIDATE_ERROR_CODE.NaN,
+          code: ERROR_CODE.invalidType,
+          path: this || [],
           schema,
           subject,
         })
@@ -150,7 +144,8 @@ export function validateBaseSchemaSubject(
 
       if (Number.isFinite(subject) === false) {
         return error({
-          code: VALIDATE_ERROR_CODE.infinity,
+          code: ERROR_CODE.invalidType,
+          path: this || [],
           schema,
           subject,
         })
@@ -159,7 +154,8 @@ export function validateBaseSchemaSubject(
       if (typeof schema.min === 'number') {
         if (subject < schema.min) {
           return error({
-            code: VALIDATE_ERROR_CODE.minRange,
+            code: ERROR_CODE.invalidRange,
+            path: this || [],
             schema,
             subject,
           })
@@ -169,7 +165,8 @@ export function validateBaseSchemaSubject(
       if (typeof schema.max === 'number') {
         if (subject > schema.max) {
           return error({
-            code: VALIDATE_ERROR_CODE.maxRange,
+            code: ERROR_CODE.invalidRange,
+            path: this || [],
             schema,
             subject,
           })
@@ -186,7 +183,8 @@ export function validateBaseSchemaSubject(
         }
 
         return error({
-          code: VALIDATE_ERROR_CODE.invalidType,
+          code: ERROR_CODE.invalidType,
+          path: this || [],
           schema,
           subject,
         })
@@ -202,7 +200,8 @@ export function validateBaseSchemaSubject(
         }
 
         return error({
-          code: VALIDATE_ERROR_CODE.invalidType,
+          code: ERROR_CODE.invalidType,
+          path: this || [],
           schema,
           subject,
         })
@@ -212,7 +211,8 @@ export function validateBaseSchemaSubject(
 
       if (unionSet.has(subject) === false) {
         return error({
-          code: VALIDATE_ERROR_CODE.notInUnion,
+          code: ERROR_CODE.invalidType,
+          path: this || [],
           schema,
           subject,
         })
@@ -228,7 +228,8 @@ export function validateBaseSchemaSubject(
         }
 
         return error({
-          code: VALIDATE_ERROR_CODE.invalidType,
+          code: ERROR_CODE.invalidType,
+          path: this || [],
           schema,
           subject,
         })
@@ -238,7 +239,8 @@ export function validateBaseSchemaSubject(
 
       if (unionSet.has(subject) === false) {
         return error({
-          code: VALIDATE_ERROR_CODE.notInUnion,
+          code: ERROR_CODE.invalidType,
+          path: this || [],
           schema,
           subject,
         })

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,4 +1,4 @@
-import type { Schema, BaseSchema } from './types/compound-schema-types'
+import type { Schema } from './types/compound-schema-types'
 
 export type ErrorCode = (typeof ERROR_CODE)[keyof typeof ERROR_CODE]
 
@@ -9,38 +9,14 @@ export type InvalidSubject = {
   path: ErrorPath
 }
 
-export type ValidateErrorCode =
-  (typeof VALIDATE_ERROR_CODE)[keyof typeof VALIDATE_ERROR_CODE]
-
-export type BaseSchemaValidateError = {
-  code: ValidateErrorCode
-  schema: BaseSchema
-  subject: unknown
-}
-
 export type ErrorPath = Array<
   string /* object key */ | number /* array index */
 >
-
-export type ValidateError = {
-  path: ErrorPath
-  schema: Schema
-  subject: unknown
-}
 
 export const ERROR_CODE = {
   invalidType: 'INVALID_TYPE',
   invalidRange: 'INVALID_RANGE',
 }
-
-export const VALIDATE_ERROR_CODE = {
-  invalidType: 'INVALID_TYPE',
-  NaN: 'NOT_A_NUMBER',
-  infinity: 'INFINITY',
-  minRange: 'MIN_RANGE',
-  maxRange: 'MAX_RANGE',
-  notInUnion: 'NOT_IN_UNION',
-} as const
 
 export const PROGRAMMATICALLY_DEFINED_ERROR_MSG = {
   optionalDefined: 'Schema "optional" is already defined',

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,15 +1,16 @@
 import type { Schema, BaseSchema } from './types/compound-schema-types'
 
-export type ParseErrorCode =
-  (typeof PARSE_ERROR_CODE)[keyof typeof PARSE_ERROR_CODE]
+export type ErrorCode = (typeof ERROR_CODE)[keyof typeof ERROR_CODE]
+
+export type InvalidSubject = {
+  code: ErrorCode
+  schema: Schema
+  subject: unknown
+  path: ErrorPath
+}
+
 export type ValidateErrorCode =
   (typeof VALIDATE_ERROR_CODE)[keyof typeof VALIDATE_ERROR_CODE]
-
-export type BaseSchemaParseError = {
-  code: ParseErrorCode
-  schema: BaseSchema
-  subject: unknown
-}
 
 export type BaseSchemaValidateError = {
   code: ValidateErrorCode
@@ -21,29 +22,16 @@ export type ErrorPath = Array<
   string /* object key */ | number /* array index */
 >
 
-export type ParseError = {
-  path: ErrorPath
-  schema: Schema
-  subject: unknown
-}
-
 export type ValidateError = {
   path: ErrorPath
   schema: Schema
   subject: unknown
 }
 
-export const PARSE_ERROR_CODE = {
+export const ERROR_CODE = {
   invalidType: 'INVALID_TYPE',
-  NaN: 'NOT_A_NUMBER',
-  infinity: 'INFINITY',
-  minRange: 'MIN_RANGE',
-  maxRange: 'MAX_RANGE',
-  notInUnion: 'NOT_IN_UNION',
-  schemaDefaultMinRange: 'SCHEMA_DEFAULT_MIN_RANGE',
-  schemaDefaultMaxRange: 'SCHEMA_DEFAULT_MAX_RANGE',
-  schemaDefaultNotInUnion: 'SCHEMA_DEFAULT_NOT_IN_UNION',
-} as const
+  invalidRange: 'INVALID_RANGE',
+}
 
 export const VALIDATE_ERROR_CODE = {
   invalidType: 'INVALID_TYPE',

--- a/src/general-schema-parser.ts
+++ b/src/general-schema-parser.ts
@@ -1,21 +1,21 @@
 import { error, data } from './utils/fp'
-import { PARSE_ERROR_CODE } from './error'
+import { ERROR_CODE } from './error'
 import { parseBaseSchemaSubject } from './base-schema-parser'
 
 import type { EitherError } from './utils/fp'
 import type { Schema, Con_Schema_SubjT_P } from './types/compound-schema-types'
-import type { ParseError, ErrorPath } from './error'
+import type { InvalidSubject, ErrorPath } from './error'
 
 export function parse<T extends Schema>(
   schema: T,
   subject: unknown
-): EitherError<ParseError[], Con_Schema_SubjT_P<T>>
+): EitherError<InvalidSubject[], Con_Schema_SubjT_P<T>>
 
 export function parse(
-  this: ErrorPath | undefined,
+  this: ErrorPath | void,
   schema: Schema,
   subject: unknown
-): EitherError<ParseError[], unknown> {
+): EitherError<InvalidSubject[], unknown> {
   if (
     typeof schema === 'string' ||
     schema.type === 'string' ||
@@ -24,16 +24,16 @@ export function parse(
     schema.type === 'stringUnion' ||
     schema.type === 'numberUnion'
   ) {
-    const parsed = parseBaseSchemaSubject(schema, subject)
+    const parsed = parseBaseSchemaSubject.bind(this)(schema, subject)
 
     if (parsed.error) {
-      return error([{ ...parsed.error, path: this || [] }])
+      return error([parsed.error])
     }
 
     return parsed
   }
 
-  const errors: ParseError[] = []
+  const errors: InvalidSubject[] = []
 
   if (schema.type === 'object') {
     if (schema.optional) {
@@ -49,7 +49,7 @@ export function parse(
     ) {
       return error([
         {
-          code: PARSE_ERROR_CODE.invalidType,
+          code: ERROR_CODE.invalidType,
           path: this || [],
           schema,
           subject,
@@ -92,7 +92,7 @@ export function parse(
 
     return error([
       {
-        code: PARSE_ERROR_CODE.invalidType,
+        code: ERROR_CODE.invalidType,
         path: this || [],
         subject,
         schema,

--- a/src/general-schema-parser.ts
+++ b/src/general-schema-parser.ts
@@ -120,5 +120,33 @@ export function parse(
     return error(errors)
   }
 
+  if (
+    typeof schema.minLength === 'number' &&
+    result.length < schema.minLength
+  ) {
+    return error([
+      {
+        code: ERROR_CODE.invalidRange,
+        path: this || [],
+        subject,
+        schema,
+      },
+    ])
+  }
+
+  if (
+    typeof schema.maxLength === 'number' &&
+    result.length > schema.maxLength
+  ) {
+    return error([
+      {
+        code: ERROR_CODE.invalidRange,
+        path: this || [],
+        subject,
+        schema,
+      },
+    ])
+  }
+
   return data(result)
 }

--- a/src/general-schema-validator.ts
+++ b/src/general-schema-validator.ts
@@ -112,5 +112,33 @@ export function validate(
     return error(errors)
   }
 
+  if (
+    typeof schema.minLength === 'number' &&
+    subject.length < schema.minLength
+  ) {
+    return error([
+      {
+        code: ERROR_CODE.invalidRange,
+        path: this || [],
+        subject,
+        schema,
+      },
+    ])
+  }
+
+  if (
+    typeof schema.maxLength === 'number' &&
+    subject.length > schema.maxLength
+  ) {
+    return error([
+      {
+        code: ERROR_CODE.invalidRange,
+        path: this || [],
+        subject,
+        schema,
+      },
+    ])
+  }
+
   return data(subject)
 }

--- a/src/general-schema-validator.ts
+++ b/src/general-schema-validator.ts
@@ -1,21 +1,21 @@
 import { error, data } from './utils/fp'
-import { VALIDATE_ERROR_CODE } from './error'
+import { ERROR_CODE } from './error'
 import { validateBaseSchemaSubject } from './base-schema-validator'
 
 import type { EitherError } from './utils/fp'
 import type { Schema, Con_Schema_SubjT_V } from './types/compound-schema-types'
-import type { ValidateError, ErrorPath } from './error'
+import type { InvalidSubject, ErrorPath } from './error'
 
 export function validate<T extends Schema>(
   schema: T,
   subject: Con_Schema_SubjT_V<T>
-): EitherError<ValidateError[], Con_Schema_SubjT_V<T>>
+): EitherError<InvalidSubject[], Con_Schema_SubjT_V<T>>
 
 export function validate(
   this: ErrorPath | undefined,
   schema: Schema,
   subject: unknown
-): EitherError<ValidateError[], unknown> {
+): EitherError<InvalidSubject[], unknown> {
   if (
     typeof schema === 'string' ||
     schema.type === 'string' ||
@@ -24,16 +24,16 @@ export function validate(
     schema.type === 'stringUnion' ||
     schema.type === 'numberUnion'
   ) {
-    const validated = validateBaseSchemaSubject(schema, subject)
+    const validated = validateBaseSchemaSubject.bind(this)(schema, subject)
 
     if (validated.error) {
-      return error([{ ...validated.error, path: this || [] }])
+      return error([validated.error])
     }
 
     return data(subject)
   }
 
-  const errors: ValidateError[] = []
+  const errors: InvalidSubject[] = []
 
   if (schema.type === 'object') {
     if (schema.optional && subject === undefined) {
@@ -47,7 +47,7 @@ export function validate(
     ) {
       return error([
         {
-          code: VALIDATE_ERROR_CODE.invalidType,
+          code: ERROR_CODE.invalidType,
           path: this || [],
           schema,
           subject,
@@ -85,7 +85,7 @@ export function validate(
 
     return error([
       {
-        code: VALIDATE_ERROR_CODE.invalidType,
+        code: ERROR_CODE.invalidType,
         path: this || [],
         subject,
         schema,

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,7 @@ export { x } from './x-closure'
 /* Typings */
 
 export type { BaseSchema, Schema } from './types/compound-schema-types'
+export type { InvalidSubject } from './error'
 
 /* Utils */
 

--- a/src/test/base-schema-parser.test.ts
+++ b/src/test/base-schema-parser.test.ts
@@ -1,8 +1,8 @@
-import { PARSE_ERROR_CODE } from '../error'
+import { ERROR_CODE } from '../error'
 import { parseBaseSchemaSubject } from '../base-schema-parser'
 import { check, unknownX } from './test-utils'
 
-import type { BaseSchemaParseError } from '../error'
+import type { InvalidSubject } from '../error'
 import type { Schema } from '../types/compound-schema-types'
 
 describe('Parse base short schema with valid subject', () => {
@@ -53,7 +53,8 @@ describe('Parse base short schema with `null | undefined` subject', () => {
     const parsed = parseBaseSchemaSubject(schema, subject)
 
     expect(parsed.error).toEqual({
-      code: PARSE_ERROR_CODE.invalidType,
+      code: ERROR_CODE.invalidType,
+      path: [],
       schema,
       subject,
     })
@@ -73,7 +74,8 @@ describe('Parse base short schema with `null | undefined` subject', () => {
     const parsed = parseBaseSchemaSubject(schema, subject)
 
     expect(parsed.error).toEqual({
-      code: PARSE_ERROR_CODE.invalidType,
+      code: ERROR_CODE.invalidType,
+      path: [],
       schema,
       subject,
     })
@@ -95,7 +97,8 @@ describe('Parse base short schema with `null | undefined` subject', () => {
     const parsed = parseBaseSchemaSubject(schema, subject)
 
     expect(parsed.error).toEqual({
-      code: PARSE_ERROR_CODE.invalidType,
+      code: ERROR_CODE.invalidType,
+      path: [],
       schema,
       subject,
     })
@@ -115,7 +118,8 @@ describe('Parse base short schema with `null | undefined` subject', () => {
     const parsed = parseBaseSchemaSubject(schema, subject)
 
     expect(parsed.error).toEqual({
-      code: PARSE_ERROR_CODE.invalidType,
+      code: ERROR_CODE.invalidType,
+      path: [],
       schema,
       subject,
     })
@@ -137,7 +141,8 @@ describe('Parse base short schema with `null | undefined` subject', () => {
     const parsed = parseBaseSchemaSubject(schema, subject)
 
     expect(parsed.error).toEqual({
-      code: PARSE_ERROR_CODE.invalidType,
+      code: ERROR_CODE.invalidType,
+      path: [],
       schema,
       subject,
     })
@@ -157,7 +162,8 @@ describe('Parse base short schema with `null | undefined` subject', () => {
     const parsed = parseBaseSchemaSubject(schema, subject)
 
     expect(parsed.error).toEqual({
-      code: PARSE_ERROR_CODE.invalidType,
+      code: ERROR_CODE.invalidType,
+      path: [],
       schema,
       subject,
     })
@@ -179,7 +185,8 @@ describe('Parse base short schema with `null | undefined` subject', () => {
     const parsed = parseBaseSchemaSubject(schema, subject)
 
     expect(parsed.error).toEqual({
-      code: PARSE_ERROR_CODE.invalidType,
+      code: ERROR_CODE.invalidType,
+      path: [],
       schema,
       subject,
     })
@@ -199,7 +206,8 @@ describe('Parse base short schema with `null | undefined` subject', () => {
     const parsed = parseBaseSchemaSubject(schema, subject)
 
     expect(parsed.error).toEqual({
-      code: PARSE_ERROR_CODE.invalidType,
+      code: ERROR_CODE.invalidType,
+      path: [],
       schema,
       subject,
     })
@@ -221,7 +229,8 @@ describe('Number base schema invalid subject parsing special cases', () => {
     const parsed = parseBaseSchemaSubject(schema, subject)
 
     expect(parsed.error).toEqual({
-      code: PARSE_ERROR_CODE.NaN,
+      code: ERROR_CODE.invalidType,
+      path: [],
       schema,
       subject,
     })
@@ -233,7 +242,8 @@ describe('Number base schema invalid subject parsing special cases', () => {
     const parsed = parseBaseSchemaSubject(schema, subject)
 
     expect(parsed.error).toEqual({
-      code: PARSE_ERROR_CODE.NaN,
+      code: ERROR_CODE.invalidType,
+      path: [],
       schema,
       subject,
     })
@@ -245,7 +255,8 @@ describe('Number base schema invalid subject parsing special cases', () => {
     const parsed = parseBaseSchemaSubject(schema, subject)
 
     expect(parsed.error).toEqual({
-      code: PARSE_ERROR_CODE.infinity,
+      code: ERROR_CODE.invalidType,
+      path: [],
       schema,
       subject,
     })
@@ -257,7 +268,8 @@ describe('Number base schema invalid subject parsing special cases', () => {
     const parsed = parseBaseSchemaSubject(schema, subject)
 
     expect(parsed.error).toEqual({
-      code: PARSE_ERROR_CODE.infinity,
+      code: ERROR_CODE.invalidType,
+      path: [],
       schema,
       subject,
     })
@@ -269,7 +281,8 @@ describe('Number base schema invalid subject parsing special cases', () => {
     const parsed = parseBaseSchemaSubject(schema, subject)
 
     expect(parsed.error).toEqual({
-      code: PARSE_ERROR_CODE.infinity,
+      code: ERROR_CODE.invalidType,
+      path: [],
       schema,
       subject,
     })
@@ -281,7 +294,8 @@ describe('Number base schema invalid subject parsing special cases', () => {
     const parsed = parseBaseSchemaSubject(schema, subject)
 
     expect(parsed.error).toEqual({
-      code: PARSE_ERROR_CODE.infinity,
+      code: ERROR_CODE.invalidType,
+      path: [],
       schema,
       subject,
     })
@@ -296,9 +310,9 @@ describe('Parse base short schema TYPE INFERENCE check', () => {
     const result = parseBaseSchemaSubject(schema, 'x')
 
     if (result.error) {
-      check<BaseSchemaParseError>(unknownX as typeof result.error)
-      check<BaseSchemaParseError & { x: number }>(
-        // @ts-expect-error Property 'x' is missing in type 'BaseSchemaParseError'
+      check<InvalidSubject>(unknownX as typeof result.error)
+      check<InvalidSubject & { x: number }>(
+        // @ts-expect-error Property 'x' is missing in type 'InvalidSubject'
         unknownX as typeof result.error
       )
       throw Error('Not expected')
@@ -314,9 +328,9 @@ describe('Parse base short schema TYPE INFERENCE check', () => {
     const result = parseBaseSchemaSubject(schema, 'x')
 
     if (result.error) {
-      check<BaseSchemaParseError>(unknownX as typeof result.error)
-      check<BaseSchemaParseError & { x: number }>(
-        // @ts-expect-error Property 'x' is missing in type 'BaseSchemaParseError'
+      check<InvalidSubject>(unknownX as typeof result.error)
+      check<InvalidSubject & { x: number }>(
+        // @ts-expect-error Property 'x' is missing in type 'InvalidSubject'
         unknownX as typeof result.error
       )
       throw Error('Not expected')
@@ -334,9 +348,9 @@ describe('Parse base short schema TYPE INFERENCE check', () => {
     const result = parseBaseSchemaSubject(schema, 0)
 
     if (result.error) {
-      check<BaseSchemaParseError>(unknownX as typeof result.error)
-      check<BaseSchemaParseError & { x: number }>(
-        // @ts-expect-error Property 'x' is missing in type 'BaseSchemaParseError'
+      check<InvalidSubject>(unknownX as typeof result.error)
+      check<InvalidSubject & { x: number }>(
+        // @ts-expect-error Property 'x' is missing in type 'InvalidSubject'
         unknownX as typeof result.error
       )
       throw Error('Not expected')
@@ -352,9 +366,9 @@ describe('Parse base short schema TYPE INFERENCE check', () => {
     const result = parseBaseSchemaSubject(schema, 0)
 
     if (result.error) {
-      check<BaseSchemaParseError>(unknownX as typeof result.error)
-      check<BaseSchemaParseError & { x: number }>(
-        // @ts-expect-error Property 'x' is missing in type 'BaseSchemaParseError'
+      check<InvalidSubject>(unknownX as typeof result.error)
+      check<InvalidSubject & { x: number }>(
+        // @ts-expect-error Property 'x' is missing in type 'InvalidSubject'
         unknownX as typeof result.error
       )
       throw Error('Not expected')
@@ -372,9 +386,9 @@ describe('Parse base short schema TYPE INFERENCE check', () => {
     const result = parseBaseSchemaSubject(schema, true)
 
     if (result.error) {
-      check<BaseSchemaParseError>(unknownX as typeof result.error)
-      check<BaseSchemaParseError & { x: boolean }>(
-        // @ts-expect-error Property 'x' is missing in type 'BaseSchemaParseError'
+      check<InvalidSubject>(unknownX as typeof result.error)
+      check<InvalidSubject & { x: boolean }>(
+        // @ts-expect-error Property 'x' is missing in type 'InvalidSubject'
         unknownX as typeof result.error
       )
       throw Error('Not expected')
@@ -390,9 +404,9 @@ describe('Parse base short schema TYPE INFERENCE check', () => {
     const result = parseBaseSchemaSubject(schema, true)
 
     if (result.error) {
-      check<BaseSchemaParseError>(unknownX as typeof result.error)
-      check<BaseSchemaParseError & { x: boolean }>(
-        // @ts-expect-error Property 'x' is missing in type 'BaseSchemaParseError'
+      check<InvalidSubject>(unknownX as typeof result.error)
+      check<InvalidSubject & { x: boolean }>(
+        // @ts-expect-error Property 'x' is missing in type 'InvalidSubject'
         unknownX as typeof result.error
       )
       throw Error('Not expected')
@@ -417,9 +431,10 @@ describe('Parse base STRING detailed schema', () => {
     const schema = { type: 'string' } as const satisfies Schema
 
     const error = {
-      code: PARSE_ERROR_CODE.invalidType,
+      code: ERROR_CODE.invalidType,
+      path: [],
       schema,
-    } satisfies Omit<BaseSchemaParseError, 'subject'>
+    } satisfies Omit<InvalidSubject, 'subject'>
 
     const undefinedSubj = undefined
 
@@ -449,9 +464,10 @@ describe('Parse base STRING detailed schema', () => {
   it('parseBaseSchemaSubject: default schema property should be skipped in required schema', () => {
     const schema = { type: 'string', default: 'x' } as const satisfies Schema
     const error = {
-      code: PARSE_ERROR_CODE.invalidType,
+      code: ERROR_CODE.invalidType,
+      path: [],
       schema,
-    } satisfies Omit<BaseSchemaParseError, 'subject'>
+    } satisfies Omit<InvalidSubject, 'subject'>
 
     const undefinedSubj = undefined
 
@@ -494,9 +510,10 @@ describe('Parse base STRING detailed schema', () => {
   it('parseBaseSchemaSubject: optional schema with invalid subject', () => {
     const schema = { type: 'string', optional: true } as const satisfies Schema
     const error = {
-      code: PARSE_ERROR_CODE.invalidType,
+      code: ERROR_CODE.invalidType,
+      path: [],
       schema,
-    } satisfies Omit<BaseSchemaParseError, 'subject'>
+    } satisfies Omit<InvalidSubject, 'subject'>
 
     const numberSubj = 0
 
@@ -548,9 +565,10 @@ describe('Parse base STRING detailed schema', () => {
     } as const satisfies Schema
 
     const error = {
-      code: PARSE_ERROR_CODE.invalidType,
+      code: ERROR_CODE.invalidType,
+      path: [],
       schema,
-    } satisfies Omit<BaseSchemaParseError, 'subject'>
+    } satisfies Omit<InvalidSubject, 'subject'>
 
     const numberSubj = 0
 
@@ -590,10 +608,11 @@ describe('Parse base STRING detailed schema', () => {
     const subject = ''
 
     const error = {
-      code: PARSE_ERROR_CODE.minRange,
+      code: ERROR_CODE.invalidRange,
+      path: [],
       schema,
       subject,
-    } satisfies BaseSchemaParseError
+    } satisfies InvalidSubject
 
     expect(parseBaseSchemaSubject(schema, subject).data).toBe(undefined)
     expect(parseBaseSchemaSubject(schema, subject).error).toEqual(error)
@@ -620,10 +639,11 @@ describe('Parse base STRING detailed schema', () => {
     const subject = 'x'
 
     const error = {
-      code: PARSE_ERROR_CODE.maxRange,
+      code: ERROR_CODE.invalidRange,
+      path: [],
       schema,
       subject,
-    } satisfies BaseSchemaParseError
+    } satisfies InvalidSubject
 
     expect(parseBaseSchemaSubject(schema, subject).data).toBe(undefined)
     expect(parseBaseSchemaSubject(schema, subject).error).toEqual(error)
@@ -642,10 +662,11 @@ describe('Parse base STRING detailed schema', () => {
     const subject = undefined
 
     const error = {
-      code: PARSE_ERROR_CODE.schemaDefaultMinRange,
+      code: ERROR_CODE.invalidRange,
       subject: defaultValue,
+      path: [],
       schema,
-    } satisfies BaseSchemaParseError
+    } satisfies InvalidSubject
 
     expect(parseBaseSchemaSubject(schema, subject).data).toBe(undefined)
     expect(parseBaseSchemaSubject(schema, subject).error).toEqual(error)
@@ -664,10 +685,11 @@ describe('Parse base STRING detailed schema', () => {
     const subject = undefined
 
     const error = {
-      code: PARSE_ERROR_CODE.schemaDefaultMaxRange,
+      code: ERROR_CODE.invalidRange,
       subject: defaultValue,
+      path: [],
       schema,
-    } satisfies BaseSchemaParseError
+    } satisfies InvalidSubject
 
     expect(parseBaseSchemaSubject(schema, subject).data).toBe(undefined)
     expect(parseBaseSchemaSubject(schema, subject).error).toEqual(error)
@@ -687,9 +709,10 @@ describe('Parse base NUMBER detailed schema', () => {
     const schema = { type: 'number' } as const satisfies Schema
 
     const error = {
-      code: PARSE_ERROR_CODE.invalidType,
+      code: ERROR_CODE.invalidType,
+      path: [],
       schema,
-    } satisfies Omit<BaseSchemaParseError, 'subject'>
+    } satisfies Omit<InvalidSubject, 'subject'>
 
     const undefinedSubj = undefined
 
@@ -719,9 +742,10 @@ describe('Parse base NUMBER detailed schema', () => {
   it('parseBaseSchemaSubject: default schema property should be skipped in required schema', () => {
     const schema = { type: 'number', default: 0 } as const satisfies Schema
     const error = {
-      code: PARSE_ERROR_CODE.invalidType,
+      code: ERROR_CODE.invalidType,
+      path: [],
       schema,
-    } satisfies Omit<BaseSchemaParseError, 'subject'>
+    } satisfies Omit<InvalidSubject, 'subject'>
 
     const undefinedSubj = undefined
 
@@ -764,9 +788,10 @@ describe('Parse base NUMBER detailed schema', () => {
   it('parseBaseSchemaSubject: optional schema with invalid subject', () => {
     const schema = { type: 'number', optional: true } as const satisfies Schema
     const error = {
-      code: PARSE_ERROR_CODE.invalidType,
+      code: ERROR_CODE.invalidType,
+      path: [],
       schema,
-    } satisfies Omit<BaseSchemaParseError, 'subject'>
+    } satisfies Omit<InvalidSubject, 'subject'>
 
     const stringSubj = 'x'
 
@@ -818,9 +843,10 @@ describe('Parse base NUMBER detailed schema', () => {
     } as const satisfies Schema
 
     const error = {
-      code: PARSE_ERROR_CODE.invalidType,
+      code: ERROR_CODE.invalidType,
+      path: [],
       schema,
-    } satisfies Omit<BaseSchemaParseError, 'subject'>
+    } satisfies Omit<InvalidSubject, 'subject'>
 
     const stringSubj = 'x'
 
@@ -860,10 +886,11 @@ describe('Parse base NUMBER detailed schema', () => {
     const subject = 0
 
     const error = {
-      code: PARSE_ERROR_CODE.minRange,
+      code: ERROR_CODE.invalidRange,
+      path: [],
       schema,
       subject,
-    } satisfies BaseSchemaParseError
+    } satisfies InvalidSubject
 
     expect(parseBaseSchemaSubject(schema, subject).data).toBe(undefined)
     expect(parseBaseSchemaSubject(schema, subject).error).toEqual(error)
@@ -890,10 +917,11 @@ describe('Parse base NUMBER detailed schema', () => {
     const subject = 1
 
     const error = {
-      code: PARSE_ERROR_CODE.maxRange,
+      code: ERROR_CODE.invalidRange,
+      path: [],
       schema,
       subject,
-    } satisfies BaseSchemaParseError
+    } satisfies InvalidSubject
 
     expect(parseBaseSchemaSubject(schema, subject).data).toBe(undefined)
     expect(parseBaseSchemaSubject(schema, subject).error).toEqual(error)
@@ -912,10 +940,11 @@ describe('Parse base NUMBER detailed schema', () => {
     const subject = undefined
 
     const error = {
-      code: PARSE_ERROR_CODE.schemaDefaultMinRange,
+      code: ERROR_CODE.invalidRange,
       subject: defaultValue,
+      path: [],
       schema,
-    } satisfies BaseSchemaParseError
+    } satisfies InvalidSubject
 
     expect(parseBaseSchemaSubject(schema, subject).data).toBe(undefined)
     expect(parseBaseSchemaSubject(schema, subject).error).toEqual(error)
@@ -934,10 +963,11 @@ describe('Parse base NUMBER detailed schema', () => {
     const subject = undefined
 
     const error = {
-      code: PARSE_ERROR_CODE.schemaDefaultMaxRange,
+      code: ERROR_CODE.invalidRange,
       subject: defaultValue,
+      path: [],
       schema,
-    } satisfies BaseSchemaParseError
+    } satisfies InvalidSubject
 
     expect(parseBaseSchemaSubject(schema, subject).data).toBe(undefined)
     expect(parseBaseSchemaSubject(schema, subject).error).toEqual(error)
@@ -947,10 +977,11 @@ describe('Parse base NUMBER detailed schema', () => {
     const schema = { type: 'number' } as const satisfies Schema
     const subject = NaN
     const error = {
-      code: PARSE_ERROR_CODE.NaN,
+      code: ERROR_CODE.invalidType,
+      path: [],
       schema,
       subject,
-    } satisfies BaseSchemaParseError
+    } satisfies InvalidSubject
 
     expect(parseBaseSchemaSubject(schema, subject).data).toBe(undefined)
     expect(parseBaseSchemaSubject(schema, subject).error).toEqual(error)
@@ -960,10 +991,11 @@ describe('Parse base NUMBER detailed schema', () => {
     const schema = { type: 'number' } as const satisfies Schema
     const subject = Infinity
     const error = {
-      code: PARSE_ERROR_CODE.infinity,
+      code: ERROR_CODE.invalidType,
+      path: [],
       schema,
       subject,
-    } satisfies BaseSchemaParseError
+    } satisfies InvalidSubject
 
     expect(parseBaseSchemaSubject(schema, subject).data).toBe(undefined)
     expect(parseBaseSchemaSubject(schema, subject).error).toEqual(error)
@@ -973,10 +1005,11 @@ describe('Parse base NUMBER detailed schema', () => {
     const schema = { type: 'number' } as const satisfies Schema
     const subject = -Infinity
     const error = {
-      code: PARSE_ERROR_CODE.infinity,
+      code: ERROR_CODE.invalidType,
+      path: [],
       schema,
       subject,
-    } satisfies BaseSchemaParseError
+    } satisfies InvalidSubject
 
     expect(parseBaseSchemaSubject(schema, subject).data).toBe(undefined)
     expect(parseBaseSchemaSubject(schema, subject).error).toEqual(error)
@@ -996,9 +1029,10 @@ describe('Parse base BOOLEAN detailed schema', () => {
     const schema = { type: 'boolean' } as const satisfies Schema
 
     const error = {
-      code: PARSE_ERROR_CODE.invalidType,
+      code: ERROR_CODE.invalidType,
+      path: [],
       schema,
-    } satisfies Omit<BaseSchemaParseError, 'subject'>
+    } satisfies Omit<InvalidSubject, 'subject'>
 
     const undefinedSubj = undefined
 
@@ -1028,9 +1062,10 @@ describe('Parse base BOOLEAN detailed schema', () => {
   it('parseBaseSchemaSubject: default schema property should be skipped in required schema', () => {
     const schema = { type: 'boolean', default: false } as const satisfies Schema
     const error = {
-      code: PARSE_ERROR_CODE.invalidType,
+      code: ERROR_CODE.invalidType,
+      path: [],
       schema,
-    } satisfies Omit<BaseSchemaParseError, 'subject'>
+    } satisfies Omit<InvalidSubject, 'subject'>
 
     const undefinedSubj = undefined
 
@@ -1073,9 +1108,10 @@ describe('Parse base BOOLEAN detailed schema', () => {
   it('parseBaseSchemaSubject: optional schema with invalid subject', () => {
     const schema = { type: 'boolean', optional: true } as const satisfies Schema
     const error = {
-      code: PARSE_ERROR_CODE.invalidType,
+      code: ERROR_CODE.invalidType,
+      path: [],
       schema,
-    } satisfies Omit<BaseSchemaParseError, 'subject'>
+    } satisfies Omit<InvalidSubject, 'subject'>
 
     const stringSubj = 'x'
 
@@ -1120,9 +1156,10 @@ describe('Parse base STRING UNION detailed schema', () => {
     } as const satisfies Schema
 
     const error = {
-      code: PARSE_ERROR_CODE.invalidType,
+      code: ERROR_CODE.invalidType,
+      path: [],
       schema,
-    } satisfies Omit<BaseSchemaParseError, 'subject'>
+    } satisfies Omit<InvalidSubject, 'subject'>
 
     const undefinedSubj = undefined
 
@@ -1153,7 +1190,7 @@ describe('Parse base STRING UNION detailed schema', () => {
     expect(parseBaseSchemaSubject(schema, stringZSubj).data).toBe(undefined)
     expect(parseBaseSchemaSubject(schema, stringZSubj).error).toEqual({
       ...error,
-      code: PARSE_ERROR_CODE.notInUnion,
+      code: ERROR_CODE.invalidType,
       subject: stringZSubj,
     })
   })
@@ -1166,9 +1203,10 @@ describe('Parse base STRING UNION detailed schema', () => {
     } as const satisfies Schema
 
     const error = {
-      code: PARSE_ERROR_CODE.invalidType,
+      code: ERROR_CODE.invalidType,
+      path: [],
       schema,
-    } satisfies Omit<BaseSchemaParseError, 'subject'>
+    } satisfies Omit<InvalidSubject, 'subject'>
 
     const undefinedSubj = undefined
 
@@ -1230,9 +1268,10 @@ describe('Parse base STRING UNION detailed schema', () => {
     } as const satisfies Schema
 
     const error = {
-      code: PARSE_ERROR_CODE.invalidType,
+      code: ERROR_CODE.invalidType,
+      path: [],
       schema,
-    } satisfies Omit<BaseSchemaParseError, 'subject'>
+    } satisfies Omit<InvalidSubject, 'subject'>
 
     const numberSubj = 0
 
@@ -1255,7 +1294,7 @@ describe('Parse base STRING UNION detailed schema', () => {
     expect(parseBaseSchemaSubject(schema, stringZSubj).data).toBe(undefined)
     expect(parseBaseSchemaSubject(schema, stringZSubj).error).toEqual({
       ...error,
-      code: PARSE_ERROR_CODE.notInUnion,
+      code: ERROR_CODE.invalidType,
       subject: stringZSubj,
     })
   })
@@ -1295,9 +1334,10 @@ describe('Parse base STRING UNION detailed schema', () => {
     } as const satisfies Schema
 
     const error = {
-      code: PARSE_ERROR_CODE.invalidType,
+      code: ERROR_CODE.invalidType,
+      path: [],
       schema,
-    } satisfies Omit<BaseSchemaParseError, 'subject'>
+    } satisfies Omit<InvalidSubject, 'subject'>
 
     const numberSubj = 0
 
@@ -1329,10 +1369,11 @@ describe('Parse base STRING UNION detailed schema', () => {
     const subject = undefined
 
     const error = {
-      code: PARSE_ERROR_CODE.schemaDefaultNotInUnion,
+      code: ERROR_CODE.invalidType,
       subject: defaultValue,
+      path: [],
       schema,
-    } satisfies BaseSchemaParseError
+    } satisfies InvalidSubject
 
     expect(parseBaseSchemaSubject(schema, subject).data).toBe(undefined)
     expect(parseBaseSchemaSubject(schema, subject).error).toEqual(error)
@@ -1364,9 +1405,10 @@ describe('Parse base NUMBER UNION detailed schema', () => {
     } as const satisfies Schema
 
     const error = {
-      code: PARSE_ERROR_CODE.invalidType,
+      code: ERROR_CODE.invalidType,
+      path: [],
       schema,
-    } satisfies Omit<BaseSchemaParseError, 'subject'>
+    } satisfies Omit<InvalidSubject, 'subject'>
 
     const undefinedSubj = undefined
 
@@ -1397,7 +1439,7 @@ describe('Parse base NUMBER UNION detailed schema', () => {
     expect(parseBaseSchemaSubject(schema, number2Subj).data).toBe(undefined)
     expect(parseBaseSchemaSubject(schema, number2Subj).error).toEqual({
       ...error,
-      code: PARSE_ERROR_CODE.notInUnion,
+      code: ERROR_CODE.invalidType,
       subject: number2Subj,
     })
   })
@@ -1410,9 +1452,10 @@ describe('Parse base NUMBER UNION detailed schema', () => {
     } as const satisfies Schema
 
     const error = {
-      code: PARSE_ERROR_CODE.invalidType,
+      code: ERROR_CODE.invalidType,
+      path: [],
       schema,
-    } satisfies Omit<BaseSchemaParseError, 'subject'>
+    } satisfies Omit<InvalidSubject, 'subject'>
 
     const undefinedSubj = undefined
 
@@ -1475,9 +1518,10 @@ describe('Parse base NUMBER UNION detailed schema', () => {
     } as const satisfies Schema
 
     const error = {
-      code: PARSE_ERROR_CODE.invalidType,
+      code: ERROR_CODE.invalidType,
+      path: [],
       schema,
-    } satisfies Omit<BaseSchemaParseError, 'subject'>
+    } satisfies Omit<InvalidSubject, 'subject'>
 
     const stringSubj = 'x'
 
@@ -1500,7 +1544,7 @@ describe('Parse base NUMBER UNION detailed schema', () => {
     expect(parseBaseSchemaSubject(schema, number2Subj).data).toBe(undefined)
     expect(parseBaseSchemaSubject(schema, number2Subj).error).toEqual({
       ...error,
-      code: PARSE_ERROR_CODE.notInUnion,
+      code: ERROR_CODE.invalidType,
       subject: number2Subj,
     })
   })
@@ -1540,9 +1584,10 @@ describe('Parse base NUMBER UNION detailed schema', () => {
     } as const satisfies Schema
 
     const error = {
-      code: PARSE_ERROR_CODE.invalidType,
+      code: ERROR_CODE.invalidType,
+      path: [],
       schema,
-    } satisfies Omit<BaseSchemaParseError, 'subject'>
+    } satisfies Omit<InvalidSubject, 'subject'>
 
     const stringSubj = 'x'
 
@@ -1574,10 +1619,11 @@ describe('Parse base NUMBER UNION detailed schema', () => {
     const subject = undefined
 
     const error = {
-      code: PARSE_ERROR_CODE.schemaDefaultNotInUnion,
+      code: ERROR_CODE.invalidType,
       subject: defaultValue,
+      path: [],
       schema,
-    } satisfies BaseSchemaParseError
+    } satisfies InvalidSubject
 
     expect(parseBaseSchemaSubject(schema, subject).data).toBe(undefined)
     expect(parseBaseSchemaSubject(schema, subject).error).toEqual(error)
@@ -1592,9 +1638,9 @@ describe('Parse base detailed schema TYPE INFERENCE check', () => {
     const result = parseBaseSchemaSubject(schema, 'x')
 
     if (result.error) {
-      check<BaseSchemaParseError>(unknownX as typeof result.error)
-      check<BaseSchemaParseError & { x: number }>(
-        // @ts-expect-error Property 'x' is missing in type 'BaseSchemaParseError'
+      check<InvalidSubject>(unknownX as typeof result.error)
+      check<InvalidSubject & { x: number }>(
+        // @ts-expect-error Property 'x' is missing in type 'InvalidSubject'
         unknownX as typeof result.error
       )
       throw Error('Not expected')
@@ -1611,9 +1657,9 @@ describe('Parse base detailed schema TYPE INFERENCE check', () => {
     const result = parseBaseSchemaSubject(schema, undefined)
 
     if (result.error) {
-      check<BaseSchemaParseError>(unknownX as typeof result.error)
-      check<BaseSchemaParseError & { x: number }>(
-        // @ts-expect-error Property 'x' is missing in type 'BaseSchemaParseError'
+      check<InvalidSubject>(unknownX as typeof result.error)
+      check<InvalidSubject & { x: number }>(
+        // @ts-expect-error Property 'x' is missing in type 'InvalidSubject'
         unknownX as typeof result.error
       )
       throw Error('Not expected')
@@ -1634,9 +1680,9 @@ describe('Parse base detailed schema TYPE INFERENCE check', () => {
     const result = parseBaseSchemaSubject(schema, undefined)
 
     if (result.error) {
-      check<BaseSchemaParseError>(unknownX as typeof result.error)
-      check<BaseSchemaParseError & { x: number }>(
-        // @ts-expect-error Property 'x' is missing in type 'BaseSchemaParseError'
+      check<InvalidSubject>(unknownX as typeof result.error)
+      check<InvalidSubject & { x: number }>(
+        // @ts-expect-error Property 'x' is missing in type 'InvalidSubject'
         unknownX as typeof result.error
       )
       throw Error('Not expected')
@@ -1654,9 +1700,9 @@ describe('Parse base detailed schema TYPE INFERENCE check', () => {
     const result = parseBaseSchemaSubject(schema, 0)
 
     if (result.error) {
-      check<BaseSchemaParseError>(unknownX as typeof result.error)
-      check<BaseSchemaParseError & { x: number }>(
-        // @ts-expect-error Property 'x' is missing in type 'BaseSchemaParseError'
+      check<InvalidSubject>(unknownX as typeof result.error)
+      check<InvalidSubject & { x: number }>(
+        // @ts-expect-error Property 'x' is missing in type 'InvalidSubject'
         unknownX as typeof result.error
       )
       throw Error('Not expected')
@@ -1673,9 +1719,9 @@ describe('Parse base detailed schema TYPE INFERENCE check', () => {
     const result = parseBaseSchemaSubject(schema, undefined)
 
     if (result.error) {
-      check<BaseSchemaParseError>(unknownX as typeof result.error)
-      check<BaseSchemaParseError & { x: number }>(
-        // @ts-expect-error Property 'x' is missing in type 'BaseSchemaParseError'
+      check<InvalidSubject>(unknownX as typeof result.error)
+      check<InvalidSubject & { x: number }>(
+        // @ts-expect-error Property 'x' is missing in type 'InvalidSubject'
         unknownX as typeof result.error
       )
       throw Error('Not expected')
@@ -1696,9 +1742,9 @@ describe('Parse base detailed schema TYPE INFERENCE check', () => {
     const result = parseBaseSchemaSubject(schema, undefined)
 
     if (result.error) {
-      check<BaseSchemaParseError>(unknownX as typeof result.error)
-      check<BaseSchemaParseError & { x: number }>(
-        // @ts-expect-error Property 'x' is missing in type 'BaseSchemaParseError'
+      check<InvalidSubject>(unknownX as typeof result.error)
+      check<InvalidSubject & { x: number }>(
+        // @ts-expect-error Property 'x' is missing in type 'InvalidSubject'
         unknownX as typeof result.error
       )
       throw Error('Not expected')
@@ -1716,9 +1762,9 @@ describe('Parse base detailed schema TYPE INFERENCE check', () => {
     const result = parseBaseSchemaSubject(schema, false)
 
     if (result.error) {
-      check<BaseSchemaParseError>(unknownX as typeof result.error)
-      check<BaseSchemaParseError & { x: boolean }>(
-        // @ts-expect-error Property 'x' is missing in type 'BaseSchemaParseError'
+      check<InvalidSubject>(unknownX as typeof result.error)
+      check<InvalidSubject & { x: boolean }>(
+        // @ts-expect-error Property 'x' is missing in type 'InvalidSubject'
         unknownX as typeof result.error
       )
       throw Error('Not expected')
@@ -1735,9 +1781,9 @@ describe('Parse base detailed schema TYPE INFERENCE check', () => {
     const result = parseBaseSchemaSubject(schema, undefined)
 
     if (result.error) {
-      check<BaseSchemaParseError>(unknownX as typeof result.error)
-      check<BaseSchemaParseError & { x: boolean }>(
-        // @ts-expect-error Property 'x' is missing in type 'BaseSchemaParseError'
+      check<InvalidSubject>(unknownX as typeof result.error)
+      check<InvalidSubject & { x: boolean }>(
+        // @ts-expect-error Property 'x' is missing in type 'InvalidSubject'
         unknownX as typeof result.error
       )
       throw Error('Not expected')
@@ -1758,9 +1804,9 @@ describe('Parse base detailed schema TYPE INFERENCE check', () => {
     const result = parseBaseSchemaSubject(schema, undefined)
 
     if (result.error) {
-      check<BaseSchemaParseError>(unknownX as typeof result.error)
-      check<BaseSchemaParseError & { x: boolean }>(
-        // @ts-expect-error Property 'x' is missing in type 'BaseSchemaParseError'
+      check<InvalidSubject>(unknownX as typeof result.error)
+      check<InvalidSubject & { x: boolean }>(
+        // @ts-expect-error Property 'x' is missing in type 'InvalidSubject'
         unknownX as typeof result.error
       )
       throw Error('Not expected')
@@ -1782,9 +1828,9 @@ describe('Parse base detailed schema TYPE INFERENCE check', () => {
     const result = parseBaseSchemaSubject(schema, 'x')
 
     if (result.error) {
-      check<BaseSchemaParseError>(unknownX as typeof result.error)
-      check<BaseSchemaParseError & { x: boolean }>(
-        // @ts-expect-error Property 'x' is missing in type 'BaseSchemaParseError'
+      check<InvalidSubject>(unknownX as typeof result.error)
+      check<InvalidSubject & { x: boolean }>(
+        // @ts-expect-error Property 'x' is missing in type 'InvalidSubject'
         unknownX as typeof result.error
       )
       throw Error('Not expected')
@@ -1805,9 +1851,9 @@ describe('Parse base detailed schema TYPE INFERENCE check', () => {
     const result = parseBaseSchemaSubject(schema, undefined)
 
     if (result.error) {
-      check<BaseSchemaParseError>(unknownX as typeof result.error)
-      check<BaseSchemaParseError & { x: boolean }>(
-        // @ts-expect-error Property 'x' is missing in type 'BaseSchemaParseError'
+      check<InvalidSubject>(unknownX as typeof result.error)
+      check<InvalidSubject & { x: boolean }>(
+        // @ts-expect-error Property 'x' is missing in type 'InvalidSubject'
         unknownX as typeof result.error
       )
       throw Error('Not expected')
@@ -1829,9 +1875,9 @@ describe('Parse base detailed schema TYPE INFERENCE check', () => {
     const result = parseBaseSchemaSubject(schema, undefined)
 
     if (result.error) {
-      check<BaseSchemaParseError>(unknownX as typeof result.error)
-      check<BaseSchemaParseError & { x: boolean }>(
-        // @ts-expect-error Property 'x' is missing in type 'BaseSchemaParseError'
+      check<InvalidSubject>(unknownX as typeof result.error)
+      check<InvalidSubject & { x: boolean }>(
+        // @ts-expect-error Property 'x' is missing in type 'InvalidSubject'
         unknownX as typeof result.error
       )
       throw Error('Not expected')
@@ -1853,9 +1899,9 @@ describe('Parse base detailed schema TYPE INFERENCE check', () => {
     const result = parseBaseSchemaSubject(schema, 0)
 
     if (result.error) {
-      check<BaseSchemaParseError>(unknownX as typeof result.error)
-      check<BaseSchemaParseError & { x: boolean }>(
-        // @ts-expect-error Property 'x' is missing in type 'BaseSchemaParseError'
+      check<InvalidSubject>(unknownX as typeof result.error)
+      check<InvalidSubject & { x: boolean }>(
+        // @ts-expect-error Property 'x' is missing in type 'InvalidSubject'
         unknownX as typeof result.error
       )
       throw Error('Not expected')
@@ -1876,9 +1922,9 @@ describe('Parse base detailed schema TYPE INFERENCE check', () => {
     const result = parseBaseSchemaSubject(schema, undefined)
 
     if (result.error) {
-      check<BaseSchemaParseError>(unknownX as typeof result.error)
-      check<BaseSchemaParseError & { x: boolean }>(
-        // @ts-expect-error Property 'x' is missing in type 'BaseSchemaParseError'
+      check<InvalidSubject>(unknownX as typeof result.error)
+      check<InvalidSubject & { x: boolean }>(
+        // @ts-expect-error Property 'x' is missing in type 'InvalidSubject'
         unknownX as typeof result.error
       )
       throw Error('Not expected')
@@ -1900,9 +1946,9 @@ describe('Parse base detailed schema TYPE INFERENCE check', () => {
     const result = parseBaseSchemaSubject(schema, undefined)
 
     if (result.error) {
-      check<BaseSchemaParseError>(unknownX as typeof result.error)
-      check<BaseSchemaParseError & { x: boolean }>(
-        // @ts-expect-error Property 'x' is missing in type 'BaseSchemaParseError'
+      check<InvalidSubject>(unknownX as typeof result.error)
+      check<InvalidSubject & { x: boolean }>(
+        // @ts-expect-error Property 'x' is missing in type 'InvalidSubject'
         unknownX as typeof result.error
       )
       throw Error('Not expected')

--- a/src/test/base-schema-validator.test.ts
+++ b/src/test/base-schema-validator.test.ts
@@ -1,8 +1,8 @@
-import { VALIDATE_ERROR_CODE } from '../error'
+import { ERROR_CODE } from '../error'
 import { validateBaseSchemaSubject } from '../base-schema-validator'
 import { check, unknownX } from './test-utils'
 
-import type { BaseSchemaValidateError } from '../error'
+import type { InvalidSubject } from '../error'
 import type { Schema } from '../types/compound-schema-types'
 
 describe('Validate base short schema with valid subject', () => {
@@ -53,7 +53,8 @@ describe('Validate base short schema with `null | undefined` subject', () => {
     const validated = validateBaseSchemaSubject(schema, subject)
 
     expect(validated.error).toEqual({
-      code: VALIDATE_ERROR_CODE.invalidType,
+      code: ERROR_CODE.invalidType,
+      path: [],
       schema,
       subject,
     })
@@ -73,7 +74,8 @@ describe('Validate base short schema with `null | undefined` subject', () => {
     const validated = validateBaseSchemaSubject(schema, subject)
 
     expect(validated.error).toEqual({
-      code: VALIDATE_ERROR_CODE.invalidType,
+      code: ERROR_CODE.invalidType,
+      path: [],
       schema,
       subject,
     })
@@ -95,7 +97,8 @@ describe('Validate base short schema with `null | undefined` subject', () => {
     const validated = validateBaseSchemaSubject(schema, subject)
 
     expect(validated.error).toEqual({
-      code: VALIDATE_ERROR_CODE.invalidType,
+      code: ERROR_CODE.invalidType,
+      path: [],
       schema,
       subject,
     })
@@ -115,7 +118,8 @@ describe('Validate base short schema with `null | undefined` subject', () => {
     const validated = validateBaseSchemaSubject(schema, subject)
 
     expect(validated.error).toEqual({
-      code: VALIDATE_ERROR_CODE.invalidType,
+      code: ERROR_CODE.invalidType,
+      path: [],
       schema,
       subject,
     })
@@ -137,7 +141,8 @@ describe('Validate base short schema with `null | undefined` subject', () => {
     const validated = validateBaseSchemaSubject(schema, subject)
 
     expect(validated.error).toEqual({
-      code: VALIDATE_ERROR_CODE.invalidType,
+      code: ERROR_CODE.invalidType,
+      path: [],
       schema,
       subject,
     })
@@ -157,7 +162,8 @@ describe('Validate base short schema with `null | undefined` subject', () => {
     const validated = validateBaseSchemaSubject(schema, subject)
 
     expect(validated.error).toEqual({
-      code: VALIDATE_ERROR_CODE.invalidType,
+      code: ERROR_CODE.invalidType,
+      path: [],
       schema,
       subject,
     })
@@ -179,7 +185,8 @@ describe('Validate base short schema with `null | undefined` subject', () => {
     const validated = validateBaseSchemaSubject(schema, subject)
 
     expect(validated.error).toEqual({
-      code: VALIDATE_ERROR_CODE.invalidType,
+      code: ERROR_CODE.invalidType,
+      path: [],
       schema,
       subject,
     })
@@ -199,7 +206,8 @@ describe('Validate base short schema with `null | undefined` subject', () => {
     const validated = validateBaseSchemaSubject(schema, subject)
 
     expect(validated.error).toEqual({
-      code: VALIDATE_ERROR_CODE.invalidType,
+      code: ERROR_CODE.invalidType,
+      path: [],
       schema,
       subject,
     })
@@ -221,7 +229,8 @@ describe('Number base schema invalid subject validation special cases', () => {
     const validated = validateBaseSchemaSubject(schema, subject)
 
     expect(validated.error).toEqual({
-      code: VALIDATE_ERROR_CODE.NaN,
+      code: ERROR_CODE.invalidType,
+      path: [],
       schema,
       subject,
     })
@@ -233,7 +242,8 @@ describe('Number base schema invalid subject validation special cases', () => {
     const validated = validateBaseSchemaSubject(schema, subject)
 
     expect(validated.error).toEqual({
-      code: VALIDATE_ERROR_CODE.NaN,
+      code: ERROR_CODE.invalidType,
+      path: [],
       schema,
       subject,
     })
@@ -245,7 +255,8 @@ describe('Number base schema invalid subject validation special cases', () => {
     const validated = validateBaseSchemaSubject(schema, subject)
 
     expect(validated.error).toEqual({
-      code: VALIDATE_ERROR_CODE.infinity,
+      code: ERROR_CODE.invalidType,
+      path: [],
       schema,
       subject,
     })
@@ -257,7 +268,8 @@ describe('Number base schema invalid subject validation special cases', () => {
     const validated = validateBaseSchemaSubject(schema, subject)
 
     expect(validated.error).toEqual({
-      code: VALIDATE_ERROR_CODE.infinity,
+      code: ERROR_CODE.invalidType,
+      path: [],
       schema,
       subject,
     })
@@ -269,7 +281,8 @@ describe('Number base schema invalid subject validation special cases', () => {
     const validated = validateBaseSchemaSubject(schema, subject)
 
     expect(validated.error).toEqual({
-      code: VALIDATE_ERROR_CODE.infinity,
+      code: ERROR_CODE.invalidType,
+      path: [],
       schema,
       subject,
     })
@@ -281,7 +294,8 @@ describe('Number base schema invalid subject validation special cases', () => {
     const validated = validateBaseSchemaSubject(schema, subject)
 
     expect(validated.error).toEqual({
-      code: VALIDATE_ERROR_CODE.infinity,
+      code: ERROR_CODE.invalidType,
+      path: [],
       schema,
       subject,
     })
@@ -296,8 +310,8 @@ describe('Validate base short schema TYPE INFERENCE check', () => {
     const result = validateBaseSchemaSubject(schema, 'x')
 
     if (result.error) {
-      check<BaseSchemaValidateError>(unknownX as typeof result.error)
-      check<BaseSchemaValidateError & { x: number }>(
+      check<InvalidSubject>(unknownX as typeof result.error)
+      check<InvalidSubject & { x: number }>(
         // @ts-expect-error Property 'x' is missing in type 'BaseSchemaValidateError'
         unknownX as typeof result.error
       )
@@ -314,8 +328,8 @@ describe('Validate base short schema TYPE INFERENCE check', () => {
     const result = validateBaseSchemaSubject(schema, 'x')
 
     if (result.error) {
-      check<BaseSchemaValidateError>(unknownX as typeof result.error)
-      check<BaseSchemaValidateError & { x: number }>(
+      check<InvalidSubject>(unknownX as typeof result.error)
+      check<InvalidSubject & { x: number }>(
         // @ts-expect-error Property 'x' is missing in type 'BaseSchemaValidateError'
         unknownX as typeof result.error
       )
@@ -334,8 +348,8 @@ describe('Validate base short schema TYPE INFERENCE check', () => {
     const result = validateBaseSchemaSubject(schema, 0)
 
     if (result.error) {
-      check<BaseSchemaValidateError>(unknownX as typeof result.error)
-      check<BaseSchemaValidateError & { x: number }>(
+      check<InvalidSubject>(unknownX as typeof result.error)
+      check<InvalidSubject & { x: number }>(
         // @ts-expect-error Property 'x' is missing in type 'BaseSchemaValidateError'
         unknownX as typeof result.error
       )
@@ -352,8 +366,8 @@ describe('Validate base short schema TYPE INFERENCE check', () => {
     const result = validateBaseSchemaSubject(schema, 0)
 
     if (result.error) {
-      check<BaseSchemaValidateError>(unknownX as typeof result.error)
-      check<BaseSchemaValidateError & { x: number }>(
+      check<InvalidSubject>(unknownX as typeof result.error)
+      check<InvalidSubject & { x: number }>(
         // @ts-expect-error Property 'x' is missing in type 'BaseSchemaValidateError'
         unknownX as typeof result.error
       )
@@ -372,8 +386,8 @@ describe('Validate base short schema TYPE INFERENCE check', () => {
     const result = validateBaseSchemaSubject(schema, true)
 
     if (result.error) {
-      check<BaseSchemaValidateError>(unknownX as typeof result.error)
-      check<BaseSchemaValidateError & { x: boolean }>(
+      check<InvalidSubject>(unknownX as typeof result.error)
+      check<InvalidSubject & { x: boolean }>(
         // @ts-expect-error Property 'x' is missing in type 'BaseSchemaValidateError'
         unknownX as typeof result.error
       )
@@ -390,8 +404,8 @@ describe('Validate base short schema TYPE INFERENCE check', () => {
     const result = validateBaseSchemaSubject(schema, true)
 
     if (result.error) {
-      check<BaseSchemaValidateError>(unknownX as typeof result.error)
-      check<BaseSchemaValidateError & { x: boolean }>(
+      check<InvalidSubject>(unknownX as typeof result.error)
+      check<InvalidSubject & { x: boolean }>(
         // @ts-expect-error Property 'x' is missing in type 'BaseSchemaValidateError'
         unknownX as typeof result.error
       )
@@ -417,9 +431,10 @@ describe('Validate base STRING detailed schema', () => {
     const schema = { type: 'string' } as const satisfies Schema
 
     const error = {
-      code: VALIDATE_ERROR_CODE.invalidType,
+      code: ERROR_CODE.invalidType,
+      path: [],
       schema,
-    } satisfies Omit<BaseSchemaValidateError, 'subject'>
+    } satisfies Omit<InvalidSubject, 'subject'>
 
     const undefinedSubj = undefined
 
@@ -468,9 +483,10 @@ describe('Validate base STRING detailed schema', () => {
   it('validateBaseSchemaSubject: optional schema with invalid subject', () => {
     const schema = { type: 'string', optional: true } as const satisfies Schema
     const error = {
-      code: VALIDATE_ERROR_CODE.invalidType,
+      code: ERROR_CODE.invalidType,
+      path: [],
       schema,
-    } satisfies Omit<BaseSchemaValidateError, 'subject'>
+    } satisfies Omit<InvalidSubject, 'subject'>
 
     const numberSubj = 0
 
@@ -510,10 +526,11 @@ describe('Validate base STRING detailed schema', () => {
     const subject = ''
 
     const error = {
-      code: VALIDATE_ERROR_CODE.minRange,
+      code: ERROR_CODE.invalidRange,
+      path: [],
       schema,
       subject,
-    } satisfies BaseSchemaValidateError
+    } satisfies InvalidSubject
 
     expect(validateBaseSchemaSubject(schema, subject).data).toBe(undefined)
     expect(validateBaseSchemaSubject(schema, subject).error).toEqual(error)
@@ -540,10 +557,11 @@ describe('Validate base STRING detailed schema', () => {
     const subject = 'x'
 
     const error = {
-      code: VALIDATE_ERROR_CODE.maxRange,
+      code: ERROR_CODE.invalidRange,
+      path: [],
       schema,
       subject,
-    } satisfies BaseSchemaValidateError
+    } satisfies InvalidSubject
 
     expect(validateBaseSchemaSubject(schema, subject).data).toBe(undefined)
     expect(validateBaseSchemaSubject(schema, subject).error).toEqual(error)
@@ -563,9 +581,10 @@ describe('Validate base NUMBER detailed schema', () => {
     const schema = { type: 'number' } as const satisfies Schema
 
     const error = {
-      code: VALIDATE_ERROR_CODE.invalidType,
+      code: ERROR_CODE.invalidType,
+      path: [],
       schema,
-    } satisfies Omit<BaseSchemaValidateError, 'subject'>
+    } satisfies Omit<InvalidSubject, 'subject'>
 
     const undefinedSubj = undefined
 
@@ -614,9 +633,10 @@ describe('Validate base NUMBER detailed schema', () => {
   it('validateBaseSchemaSubject: optional schema with invalid subject', () => {
     const schema = { type: 'number', optional: true } as const satisfies Schema
     const error = {
-      code: VALIDATE_ERROR_CODE.invalidType,
+      code: ERROR_CODE.invalidType,
+      path: [],
       schema,
-    } satisfies Omit<BaseSchemaValidateError, 'subject'>
+    } satisfies Omit<InvalidSubject, 'subject'>
 
     const stringSubj = 'x'
 
@@ -656,10 +676,11 @@ describe('Validate base NUMBER detailed schema', () => {
     const subject = 0
 
     const error = {
-      code: VALIDATE_ERROR_CODE.minRange,
+      code: ERROR_CODE.invalidRange,
+      path: [],
       schema,
       subject,
-    } satisfies BaseSchemaValidateError
+    } satisfies InvalidSubject
 
     expect(validateBaseSchemaSubject(schema, subject).data).toBe(undefined)
     expect(validateBaseSchemaSubject(schema, subject).error).toEqual(error)
@@ -686,10 +707,11 @@ describe('Validate base NUMBER detailed schema', () => {
     const subject = 1
 
     const error = {
-      code: VALIDATE_ERROR_CODE.maxRange,
+      code: ERROR_CODE.invalidRange,
+      path: [],
       schema,
       subject,
-    } satisfies BaseSchemaValidateError
+    } satisfies InvalidSubject
 
     expect(validateBaseSchemaSubject(schema, subject).data).toBe(undefined)
     expect(validateBaseSchemaSubject(schema, subject).error).toEqual(error)
@@ -699,10 +721,11 @@ describe('Validate base NUMBER detailed schema', () => {
     const schema = { type: 'number' } as const satisfies Schema
     const subject = NaN
     const error = {
-      code: VALIDATE_ERROR_CODE.NaN,
+      code: ERROR_CODE.invalidType,
+      path: [],
       schema,
       subject,
-    } satisfies BaseSchemaValidateError
+    } satisfies InvalidSubject
 
     expect(validateBaseSchemaSubject(schema, subject).data).toBe(undefined)
     expect(validateBaseSchemaSubject(schema, subject).error).toEqual(error)
@@ -712,10 +735,11 @@ describe('Validate base NUMBER detailed schema', () => {
     const schema = { type: 'number' } as const satisfies Schema
     const subject = Infinity
     const error = {
-      code: VALIDATE_ERROR_CODE.infinity,
+      code: ERROR_CODE.invalidType,
+      path: [],
       schema,
       subject,
-    } satisfies BaseSchemaValidateError
+    } satisfies InvalidSubject
 
     expect(validateBaseSchemaSubject(schema, subject).data).toBe(undefined)
     expect(validateBaseSchemaSubject(schema, subject).error).toEqual(error)
@@ -725,10 +749,11 @@ describe('Validate base NUMBER detailed schema', () => {
     const schema = { type: 'number' } as const satisfies Schema
     const subject = -Infinity
     const error = {
-      code: VALIDATE_ERROR_CODE.infinity,
+      code: ERROR_CODE.invalidType,
+      path: [],
       schema,
       subject,
-    } satisfies BaseSchemaValidateError
+    } satisfies InvalidSubject
 
     expect(validateBaseSchemaSubject(schema, subject).data).toBe(undefined)
     expect(validateBaseSchemaSubject(schema, subject).error).toEqual(error)
@@ -748,9 +773,10 @@ describe('Validate base BOOLEAN detailed schema', () => {
     const schema = { type: 'boolean' } as const satisfies Schema
 
     const error = {
-      code: VALIDATE_ERROR_CODE.invalidType,
+      code: ERROR_CODE.invalidType,
+      path: [],
       schema,
-    } satisfies Omit<BaseSchemaValidateError, 'subject'>
+    } satisfies Omit<InvalidSubject, 'subject'>
 
     const undefinedSubj = undefined
 
@@ -801,9 +827,10 @@ describe('Validate base BOOLEAN detailed schema', () => {
   it('validateBaseSchemaSubject: optional schema with invalid subject', () => {
     const schema = { type: 'boolean', optional: true } as const satisfies Schema
     const error = {
-      code: VALIDATE_ERROR_CODE.invalidType,
+      code: ERROR_CODE.invalidType,
+      path: [],
       schema,
-    } satisfies Omit<BaseSchemaValidateError, 'subject'>
+    } satisfies Omit<InvalidSubject, 'subject'>
 
     const stringSubj = 'x'
 
@@ -848,9 +875,10 @@ describe('Validate base STRING UNION detailed schema', () => {
     } as const satisfies Schema
 
     const error = {
-      code: VALIDATE_ERROR_CODE.invalidType,
+      code: ERROR_CODE.invalidType,
+      path: [],
       schema,
-    } satisfies Omit<BaseSchemaValidateError, 'subject'>
+    } satisfies Omit<InvalidSubject, 'subject'>
 
     const undefinedSubj = undefined
 
@@ -883,7 +911,7 @@ describe('Validate base STRING UNION detailed schema', () => {
     expect(validateBaseSchemaSubject(schema, stringZSubj).data).toBe(undefined)
     expect(validateBaseSchemaSubject(schema, stringZSubj).error).toEqual({
       ...error,
-      code: VALIDATE_ERROR_CODE.notInUnion,
+      code: ERROR_CODE.invalidType,
       subject: stringZSubj,
     })
   })
@@ -926,9 +954,10 @@ describe('Validate base STRING UNION detailed schema', () => {
     } as const satisfies Schema
 
     const error = {
-      code: VALIDATE_ERROR_CODE.invalidType,
+      code: ERROR_CODE.invalidType,
+      path: [],
       schema,
-    } satisfies Omit<BaseSchemaValidateError, 'subject'>
+    } satisfies Omit<InvalidSubject, 'subject'>
 
     const nullSubj = null
 
@@ -959,7 +988,7 @@ describe('Validate base STRING UNION detailed schema', () => {
     expect(validateBaseSchemaSubject(schema, stringZSubj).data).toBe(undefined)
     expect(validateBaseSchemaSubject(schema, stringZSubj).error).toEqual({
       ...error,
-      code: VALIDATE_ERROR_CODE.notInUnion,
+      code: ERROR_CODE.invalidType,
       subject: stringZSubj,
     })
   })
@@ -990,9 +1019,10 @@ describe('Validate base NUMBER UNION detailed schema', () => {
     } as const satisfies Schema
 
     const error = {
-      code: VALIDATE_ERROR_CODE.invalidType,
+      code: ERROR_CODE.invalidType,
+      path: [],
       schema,
-    } satisfies Omit<BaseSchemaValidateError, 'subject'>
+    } satisfies Omit<InvalidSubject, 'subject'>
 
     const undefinedSubj = undefined
 
@@ -1025,7 +1055,7 @@ describe('Validate base NUMBER UNION detailed schema', () => {
     expect(validateBaseSchemaSubject(schema, number2Subj).data).toBe(undefined)
     expect(validateBaseSchemaSubject(schema, number2Subj).error).toEqual({
       ...error,
-      code: VALIDATE_ERROR_CODE.notInUnion,
+      code: ERROR_CODE.invalidType,
       subject: number2Subj,
     })
   })
@@ -1069,9 +1099,10 @@ describe('Validate base NUMBER UNION detailed schema', () => {
     } as const satisfies Schema
 
     const error = {
-      code: VALIDATE_ERROR_CODE.invalidType,
+      code: ERROR_CODE.invalidType,
+      path: [],
       schema,
-    } satisfies Omit<BaseSchemaValidateError, 'subject'>
+    } satisfies Omit<InvalidSubject, 'subject'>
 
     const nullSubj = null
 
@@ -1102,7 +1133,7 @@ describe('Validate base NUMBER UNION detailed schema', () => {
     expect(validateBaseSchemaSubject(schema, number2Subj).data).toBe(undefined)
     expect(validateBaseSchemaSubject(schema, number2Subj).error).toEqual({
       ...error,
-      code: VALIDATE_ERROR_CODE.notInUnion,
+      code: ERROR_CODE.invalidType,
       subject: number2Subj,
     })
   })
@@ -1116,8 +1147,8 @@ describe('Validate base detailed schema TYPE INFERENCE check', () => {
     const result = validateBaseSchemaSubject(schema, 'x')
 
     if (result.error) {
-      check<BaseSchemaValidateError>(unknownX as typeof result.error)
-      check<BaseSchemaValidateError & { x: number }>(
+      check<InvalidSubject>(unknownX as typeof result.error)
+      check<InvalidSubject & { x: number }>(
         // @ts-expect-error Property 'x' is missing in type 'BaseSchemaValidateError'
         unknownX as typeof result.error
       )
@@ -1135,8 +1166,8 @@ describe('Validate base detailed schema TYPE INFERENCE check', () => {
     const result = validateBaseSchemaSubject(schema, undefined)
 
     if (result.error) {
-      check<BaseSchemaValidateError>(unknownX as typeof result.error)
-      check<BaseSchemaValidateError & { x: number }>(
+      check<InvalidSubject>(unknownX as typeof result.error)
+      check<InvalidSubject & { x: number }>(
         // @ts-expect-error Property 'x' is missing in type 'BaseSchemaValidateError'
         unknownX as typeof result.error
       )
@@ -1155,8 +1186,8 @@ describe('Validate base detailed schema TYPE INFERENCE check', () => {
     const result = validateBaseSchemaSubject(schema, 0)
 
     if (result.error) {
-      check<BaseSchemaValidateError>(unknownX as typeof result.error)
-      check<BaseSchemaValidateError & { x: number }>(
+      check<InvalidSubject>(unknownX as typeof result.error)
+      check<InvalidSubject & { x: number }>(
         // @ts-expect-error Property 'x' is missing in type 'BaseSchemaValidateError'
         unknownX as typeof result.error
       )
@@ -1174,8 +1205,8 @@ describe('Validate base detailed schema TYPE INFERENCE check', () => {
     const result = validateBaseSchemaSubject(schema, undefined)
 
     if (result.error) {
-      check<BaseSchemaValidateError>(unknownX as typeof result.error)
-      check<BaseSchemaValidateError & { x: number }>(
+      check<InvalidSubject>(unknownX as typeof result.error)
+      check<InvalidSubject & { x: number }>(
         // @ts-expect-error Property 'x' is missing in type 'BaseSchemaValidateError'
         unknownX as typeof result.error
       )
@@ -1194,8 +1225,8 @@ describe('Validate base detailed schema TYPE INFERENCE check', () => {
     const result = validateBaseSchemaSubject(schema, false)
 
     if (result.error) {
-      check<BaseSchemaValidateError>(unknownX as typeof result.error)
-      check<BaseSchemaValidateError & { x: boolean }>(
+      check<InvalidSubject>(unknownX as typeof result.error)
+      check<InvalidSubject & { x: boolean }>(
         // @ts-expect-error Property 'x' is missing in type 'BaseSchemaValidateError'
         unknownX as typeof result.error
       )
@@ -1213,8 +1244,8 @@ describe('Validate base detailed schema TYPE INFERENCE check', () => {
     const result = validateBaseSchemaSubject(schema, undefined)
 
     if (result.error) {
-      check<BaseSchemaValidateError>(unknownX as typeof result.error)
-      check<BaseSchemaValidateError & { x: boolean }>(
+      check<InvalidSubject>(unknownX as typeof result.error)
+      check<InvalidSubject & { x: boolean }>(
         // @ts-expect-error Property 'x' is missing in type 'BaseSchemaValidateError'
         unknownX as typeof result.error
       )
@@ -1237,8 +1268,8 @@ describe('Validate base detailed schema TYPE INFERENCE check', () => {
     const result = validateBaseSchemaSubject(schema, 'x')
 
     if (result.error) {
-      check<BaseSchemaValidateError>(unknownX as typeof result.error)
-      check<BaseSchemaValidateError & { x: boolean }>(
+      check<InvalidSubject>(unknownX as typeof result.error)
+      check<InvalidSubject & { x: boolean }>(
         // @ts-expect-error Property 'x' is missing in type 'BaseSchemaValidateError'
         unknownX as typeof result.error
       )
@@ -1260,8 +1291,8 @@ describe('Validate base detailed schema TYPE INFERENCE check', () => {
     const result = validateBaseSchemaSubject(schema, undefined)
 
     if (result.error) {
-      check<BaseSchemaValidateError>(unknownX as typeof result.error)
-      check<BaseSchemaValidateError & { x: boolean }>(
+      check<InvalidSubject>(unknownX as typeof result.error)
+      check<InvalidSubject & { x: boolean }>(
         // @ts-expect-error Property 'x' is missing in type 'BaseSchemaValidateError'
         unknownX as typeof result.error
       )
@@ -1284,8 +1315,8 @@ describe('Validate base detailed schema TYPE INFERENCE check', () => {
     const result = validateBaseSchemaSubject(schema, 0)
 
     if (result.error) {
-      check<BaseSchemaValidateError>(unknownX as typeof result.error)
-      check<BaseSchemaValidateError & { x: boolean }>(
+      check<InvalidSubject>(unknownX as typeof result.error)
+      check<InvalidSubject & { x: boolean }>(
         // @ts-expect-error Property 'x' is missing in type 'BaseSchemaValidateError'
         unknownX as typeof result.error
       )
@@ -1307,8 +1338,8 @@ describe('Validate base detailed schema TYPE INFERENCE check', () => {
     const result = validateBaseSchemaSubject(schema, undefined)
 
     if (result.error) {
-      check<BaseSchemaValidateError>(unknownX as typeof result.error)
-      check<BaseSchemaValidateError & { x: boolean }>(
+      check<InvalidSubject>(unknownX as typeof result.error)
+      check<InvalidSubject & { x: boolean }>(
         // @ts-expect-error Property 'x' is missing in type 'BaseSchemaValidateError'
         unknownX as typeof result.error
       )

--- a/src/test/general-schema-parser.test.ts
+++ b/src/test/general-schema-parser.test.ts
@@ -852,6 +852,50 @@ describe('Parse ARRAY schema with INVALID subject', () => {
     ])
   })
 
+  it('parse: minLength INVALID_RANGE error', () => {
+    const schema = {
+      type: 'array',
+      of: 'string',
+      minLength: 2,
+    } as const satisfies Schema
+
+    const subject = ['x']
+
+    const parsed = parse(schema, subject)
+
+    expect(parsed.data).toBe(undefined)
+    expect(parsed.error).toStrictEqual([
+      {
+        code: ERROR_CODE.invalidRange,
+        path: [],
+        schema,
+        subject,
+      },
+    ])
+  })
+
+  it('parse: maxLength INVALID_RANGE error', () => {
+    const schema = {
+      type: 'array',
+      of: 'string',
+      maxLength: 1,
+    } as const satisfies Schema
+
+    const subject = ['x', 'y']
+
+    const parsed = parse(schema, subject)
+
+    expect(parsed.data).toBe(undefined)
+    expect(parsed.error).toStrictEqual([
+      {
+        code: ERROR_CODE.invalidRange,
+        path: [],
+        schema,
+        subject,
+      },
+    ])
+  })
+
   it('parse: optional array with invalid direct subject', () => {
     const schema = {
       type: 'array',

--- a/src/test/general-schema-parser.test.ts
+++ b/src/test/general-schema-parser.test.ts
@@ -1,5 +1,5 @@
 import { parse } from '../general-schema-parser'
-import { PARSE_ERROR_CODE } from '../error'
+import { ERROR_CODE } from '../error'
 import { check, unknownX } from './test-utils'
 
 import type { Schema } from '../types/compound-schema-types'
@@ -102,7 +102,7 @@ describe('Parse BASE schema with INVALID subject', () => {
     expect(parse(shortReqStrSchema, undefinedSubj).data).toBe(undefined)
     expect(parse(shortReqStrSchema, undefinedSubj).error).toStrictEqual([
       {
-        code: PARSE_ERROR_CODE.invalidType,
+        code: ERROR_CODE.invalidType,
         subject: undefinedSubj,
         schema: shortReqStrSchema,
         path: [],
@@ -115,7 +115,7 @@ describe('Parse BASE schema with INVALID subject', () => {
     expect(parse(shortOptStrSchema, numberSubj).data).toBe(undefined)
     expect(parse(shortOptStrSchema, numberSubj).error).toStrictEqual([
       {
-        code: PARSE_ERROR_CODE.invalidType,
+        code: ERROR_CODE.invalidType,
         subject: numberSubj,
         schema: shortOptStrSchema,
         path: [],
@@ -130,7 +130,7 @@ describe('Parse BASE schema with INVALID subject', () => {
     expect(parse(detailedReqStrSchema, undefinedSubj).data).toBe(undefined)
     expect(parse(detailedReqStrSchema, undefinedSubj).error).toStrictEqual([
       {
-        code: PARSE_ERROR_CODE.invalidType,
+        code: ERROR_CODE.invalidType,
         subject: undefinedSubj,
         schema: detailedReqStrSchema,
         path: [],
@@ -147,7 +147,7 @@ describe('Parse BASE schema with INVALID subject', () => {
     expect(parse(detailedOptStrSchema, numberSubj).data).toBe(undefined)
     expect(parse(detailedOptStrSchema, numberSubj).error).toStrictEqual([
       {
-        code: PARSE_ERROR_CODE.invalidType,
+        code: ERROR_CODE.invalidType,
         subject: numberSubj,
         schema: detailedOptStrSchema,
         path: [],
@@ -383,7 +383,7 @@ describe('Parse OBJECT schema with INVALID subject', () => {
     expect(parse(schema, undefinedSubj).data).toBe(undefined)
     expect(parse(schema, undefinedSubj).error).toStrictEqual([
       {
-        code: PARSE_ERROR_CODE.invalidType,
+        code: ERROR_CODE.invalidType,
         subject: undefinedSubj,
         schema,
         path: [],
@@ -395,7 +395,7 @@ describe('Parse OBJECT schema with INVALID subject', () => {
     expect(parse(schema, nullSubj).data).toBe(undefined)
     expect(parse(schema, nullSubj).error).toStrictEqual([
       {
-        code: PARSE_ERROR_CODE.invalidType,
+        code: ERROR_CODE.invalidType,
         subject: nullSubj,
         schema,
         path: [],
@@ -407,7 +407,7 @@ describe('Parse OBJECT schema with INVALID subject', () => {
     expect(parse(schema, regExpSubj).data).toBe(undefined)
     expect(parse(schema, regExpSubj).error).toStrictEqual([
       {
-        code: PARSE_ERROR_CODE.invalidType,
+        code: ERROR_CODE.invalidType,
         subject: regExpSubj,
         schema,
         path: [],
@@ -419,7 +419,7 @@ describe('Parse OBJECT schema with INVALID subject', () => {
     expect(parse(schema, arraySubj).data).toBe(undefined)
     expect(parse(schema, arraySubj).error).toStrictEqual([
       {
-        code: PARSE_ERROR_CODE.invalidType,
+        code: ERROR_CODE.invalidType,
         subject: arraySubj,
         schema,
         path: [],
@@ -431,7 +431,7 @@ describe('Parse OBJECT schema with INVALID subject', () => {
     expect(parse(schema, mapSubj).data).toBe(undefined)
     expect(parse(schema, mapSubj).error).toStrictEqual([
       {
-        code: PARSE_ERROR_CODE.invalidType,
+        code: ERROR_CODE.invalidType,
         subject: mapSubj,
         schema,
         path: [],
@@ -443,7 +443,7 @@ describe('Parse OBJECT schema with INVALID subject', () => {
     expect(parse(schema, setSubj).data).toBe(undefined)
     expect(parse(schema, setSubj).error).toStrictEqual([
       {
-        code: PARSE_ERROR_CODE.invalidType,
+        code: ERROR_CODE.invalidType,
         subject: setSubj,
         schema,
         path: [],
@@ -469,13 +469,13 @@ describe('Parse OBJECT schema with INVALID subject', () => {
     expect(parse(schema, subject).data).toBe(undefined)
     expect(parse(schema, subject).error).toStrictEqual([
       {
-        code: PARSE_ERROR_CODE.invalidType,
+        code: ERROR_CODE.invalidType,
         subject: subject[firstInvalidSubjKey],
         schema: schema.of[firstInvalidSubjKey],
         path: [firstInvalidSubjKey],
       },
       {
-        code: PARSE_ERROR_CODE.invalidType,
+        code: ERROR_CODE.invalidType,
         subject: subject[secondInvalidSubjKey],
         schema: schema.of[secondInvalidSubjKey],
         path: [secondInvalidSubjKey],
@@ -547,13 +547,13 @@ describe('Parse OBJECT schema with INVALID subject', () => {
     expect(parse(schema, subject).data).toBe(undefined)
     expect(parse(schema, subject).error).toStrictEqual([
       {
-        code: PARSE_ERROR_CODE.invalidType,
+        code: ERROR_CODE.invalidType,
         subject: invalidSubject,
         schema: 'string',
         path: ['a', 'b', 'cArr', 2, 'dArrObj'],
       },
       {
-        code: PARSE_ERROR_CODE.invalidType,
+        code: ERROR_CODE.invalidType,
         subject: invalidSubject,
         schema: 'string',
         path: ['a', 'b', 'c', 'd', 'e', 'f', 'g'],
@@ -580,7 +580,7 @@ describe('Parse OBJECT schema with INVALID subject', () => {
     expect(parse(schema, subject).data).toBe(undefined)
     expect(parse(schema, subject).error).toStrictEqual([
       {
-        code: PARSE_ERROR_CODE.invalidType,
+        code: ERROR_CODE.invalidType,
         subject: invalidSubject,
         schema: schema.of.x.of,
         path: ['x', 1],
@@ -820,7 +820,7 @@ describe('Parse ARRAY schema with INVALID subject', () => {
     expect(parse(schema, undefinedSubj).data).toBe(undefined)
     expect(parse(schema, undefinedSubj).error).toStrictEqual([
       {
-        code: PARSE_ERROR_CODE.invalidType,
+        code: ERROR_CODE.invalidType,
         subject: undefinedSubj,
         schema,
         path: [],
@@ -832,7 +832,7 @@ describe('Parse ARRAY schema with INVALID subject', () => {
     expect(parse(schema, nullSubj).data).toBe(undefined)
     expect(parse(schema, nullSubj).error).toStrictEqual([
       {
-        code: PARSE_ERROR_CODE.invalidType,
+        code: ERROR_CODE.invalidType,
         subject: nullSubj,
         schema,
         path: [],
@@ -844,7 +844,7 @@ describe('Parse ARRAY schema with INVALID subject', () => {
     expect(parse(schema, stringSubj).data).toBe(undefined)
     expect(parse(schema, stringSubj).error).toStrictEqual([
       {
-        code: PARSE_ERROR_CODE.invalidType,
+        code: ERROR_CODE.invalidType,
         subject: stringSubj,
         schema,
         path: [],
@@ -864,7 +864,7 @@ describe('Parse ARRAY schema with INVALID subject', () => {
     expect(parse(schema, strSubject).data).toBe(undefined)
     expect(parse(schema, strSubject).error).toStrictEqual([
       {
-        code: PARSE_ERROR_CODE.invalidType,
+        code: ERROR_CODE.invalidType,
         subject: strSubject,
         schema,
         path: [],
@@ -896,13 +896,13 @@ describe('Parse ARRAY schema with INVALID subject', () => {
     expect(parse(schema, subject).data).toBe(undefined)
     expect(parse(schema, subject).error).toStrictEqual([
       {
-        code: PARSE_ERROR_CODE.invalidType,
+        code: ERROR_CODE.invalidType,
         subject: invalidSubject,
         schema: schema.of,
         path: [firstInvalidIndex],
       },
       {
-        code: PARSE_ERROR_CODE.invalidType,
+        code: ERROR_CODE.invalidType,
         subject: invalidSubject,
         schema: schema.of,
         path: [secondInvalidIndex],
@@ -970,25 +970,25 @@ describe('Parse ARRAY schema with INVALID subject', () => {
     expect(parse(schema, subject).data).toBe(undefined)
     expect(parse(schema, subject).error).toStrictEqual([
       {
-        code: PARSE_ERROR_CODE.invalidType,
+        code: ERROR_CODE.invalidType,
         subject: invalidSubjForStr,
         schema: schema.of.of.of.of.of.x,
         path: [0, 0, 0, 0, 'x'],
       },
       {
-        code: PARSE_ERROR_CODE.invalidType,
+        code: ERROR_CODE.invalidType,
         subject: invalidSubjForBool,
         schema: schema.of.of.of.of.of.y,
         path: [0, 0, 0, 0, 'y'],
       },
       {
-        code: PARSE_ERROR_CODE.invalidType,
+        code: ERROR_CODE.invalidType,
         subject: invalidSubjForNumb,
         schema: schema.of.of.of.of.of.z.of.of.x,
         path: [0, 0, 0, 0, 'z', 1, 'x'],
       },
       {
-        code: PARSE_ERROR_CODE.invalidType,
+        code: ERROR_CODE.invalidType,
         subject: invalidSubjForNumb,
         schema: schema.of.of.of.of.of.z.of.of.x,
         path: [0, 0, 0, 0, 'z', 3, 'x'],

--- a/src/test/general-schema-validator.test.ts
+++ b/src/test/general-schema-validator.test.ts
@@ -812,6 +812,50 @@ describe('Validate ARRAY schema with INVALID subject', () => {
     ])
   })
 
+  it('validate: minLength INVALID_RANGE error', () => {
+    const schema = {
+      type: 'array',
+      of: 'string',
+      minLength: 2,
+    } as const satisfies Schema
+
+    const subject = ['x']
+
+    const validated = validate(schema, subject)
+
+    expect(validated.data).toBe(undefined)
+    expect(validated.error).toStrictEqual([
+      {
+        code: ERROR_CODE.invalidRange,
+        path: [],
+        schema,
+        subject,
+      },
+    ])
+  })
+
+  it('validate: maxLength INVALID_RANGE error', () => {
+    const schema = {
+      type: 'array',
+      of: 'string',
+      maxLength: 1,
+    } as const satisfies Schema
+
+    const subject = ['x', 'y']
+
+    const validated = validate(schema, subject)
+
+    expect(validated.data).toBe(undefined)
+    expect(validated.error).toStrictEqual([
+      {
+        code: ERROR_CODE.invalidRange,
+        path: [],
+        schema,
+        subject,
+      },
+    ])
+  })
+
   it('validate: required array with two invalid subject arr elements', () => {
     const schema = {
       type: 'array',

--- a/src/test/general-schema-validator.test.ts
+++ b/src/test/general-schema-validator.test.ts
@@ -1,5 +1,5 @@
 import { validate } from '../general-schema-validator'
-import { VALIDATE_ERROR_CODE } from '../error'
+import { ERROR_CODE } from '../error'
 import { check, unknownX } from './test-utils'
 
 import type { Schema } from '../types/compound-schema-types'
@@ -104,7 +104,7 @@ describe('Validate BASE schema with INVALID subject', () => {
     // @ts-expect-error for the sake of testing
     expect(validate(shortReqStrSchema, undefinedSubj).error).toStrictEqual([
       {
-        code: VALIDATE_ERROR_CODE.invalidType,
+        code: ERROR_CODE.invalidType,
         subject: undefinedSubj,
         schema: shortReqStrSchema,
         path: [],
@@ -119,7 +119,7 @@ describe('Validate BASE schema with INVALID subject', () => {
     // @ts-expect-error for the sake of testing
     expect(validate(shortOptStrSchema, numberSubj).error).toStrictEqual([
       {
-        code: VALIDATE_ERROR_CODE.invalidType,
+        code: ERROR_CODE.invalidType,
         subject: numberSubj,
         schema: shortOptStrSchema,
         path: [],
@@ -136,7 +136,7 @@ describe('Validate BASE schema with INVALID subject', () => {
     // @ts-expect-error for the sake of testing
     expect(validate(detailedReqStrSchema, undefinedSubj).error).toStrictEqual([
       {
-        code: VALIDATE_ERROR_CODE.invalidType,
+        code: ERROR_CODE.invalidType,
         subject: undefinedSubj,
         schema: detailedReqStrSchema,
         path: [],
@@ -155,7 +155,7 @@ describe('Validate BASE schema with INVALID subject', () => {
     // @ts-expect-error for the sake of testing
     expect(validate(detailedOptStrSchema, numberSubj).error).toStrictEqual([
       {
-        code: VALIDATE_ERROR_CODE.invalidType,
+        code: ERROR_CODE.invalidType,
         subject: numberSubj,
         schema: detailedOptStrSchema,
         path: [],
@@ -287,7 +287,7 @@ describe('Validate OBJECT schema with INVALID subject', () => {
     // @ts-expect-error for the sake of testing
     expect(validate(schema, undefinedSubj).error).toStrictEqual([
       {
-        code: VALIDATE_ERROR_CODE.invalidType,
+        code: ERROR_CODE.invalidType,
         subject: undefinedSubj,
         schema,
         path: [],
@@ -301,7 +301,7 @@ describe('Validate OBJECT schema with INVALID subject', () => {
     // @ts-expect-error for the sake of testing
     expect(validate(schema, nullSubj).error).toStrictEqual([
       {
-        code: VALIDATE_ERROR_CODE.invalidType,
+        code: ERROR_CODE.invalidType,
         subject: nullSubj,
         schema,
         path: [],
@@ -315,7 +315,7 @@ describe('Validate OBJECT schema with INVALID subject', () => {
     // @ts-expect-error for the sake of testing
     expect(validate(schema, regExpSubj).error).toStrictEqual([
       {
-        code: VALIDATE_ERROR_CODE.invalidType,
+        code: ERROR_CODE.invalidType,
         subject: regExpSubj,
         schema,
         path: [],
@@ -329,7 +329,7 @@ describe('Validate OBJECT schema with INVALID subject', () => {
     // @ts-expect-error for the sake of testing
     expect(validate(schema, arraySubj).error).toStrictEqual([
       {
-        code: VALIDATE_ERROR_CODE.invalidType,
+        code: ERROR_CODE.invalidType,
         subject: arraySubj,
         schema,
         path: [],
@@ -343,7 +343,7 @@ describe('Validate OBJECT schema with INVALID subject', () => {
     // @ts-expect-error for the sake of testing
     expect(validate(schema, mapSubj).error).toStrictEqual([
       {
-        code: VALIDATE_ERROR_CODE.invalidType,
+        code: ERROR_CODE.invalidType,
         subject: mapSubj,
         schema,
         path: [],
@@ -357,7 +357,7 @@ describe('Validate OBJECT schema with INVALID subject', () => {
     // @ts-expect-error for the sake of testing
     expect(validate(schema, setSubj).error).toStrictEqual([
       {
-        code: VALIDATE_ERROR_CODE.invalidType,
+        code: ERROR_CODE.invalidType,
         subject: setSubj,
         schema,
         path: [],
@@ -385,13 +385,13 @@ describe('Validate OBJECT schema with INVALID subject', () => {
     // @ts-expect-error for the sake of testing
     expect(validate(schema, subject).error).toStrictEqual([
       {
-        code: VALIDATE_ERROR_CODE.invalidType,
+        code: ERROR_CODE.invalidType,
         subject: subject[firstInvalidSubjKey],
         schema: schema.of[firstInvalidSubjKey],
         path: [firstInvalidSubjKey],
       },
       {
-        code: VALIDATE_ERROR_CODE.invalidType,
+        code: ERROR_CODE.invalidType,
         subject: subject[secondInvalidSubjKey],
         schema: schema.of[secondInvalidSubjKey],
         path: [secondInvalidSubjKey],
@@ -465,13 +465,13 @@ describe('Validate OBJECT schema with INVALID subject', () => {
     // @ts-expect-error for the sake of testing
     expect(validate(schema, subject).error).toStrictEqual([
       {
-        code: VALIDATE_ERROR_CODE.invalidType,
+        code: ERROR_CODE.invalidType,
         subject: invalidSubject,
         schema: 'string',
         path: ['a', 'b', 'cArr', 2, 'dArrObj'],
       },
       {
-        code: VALIDATE_ERROR_CODE.invalidType,
+        code: ERROR_CODE.invalidType,
         subject: invalidSubject,
         schema: 'string',
         path: ['a', 'b', 'c', 'd', 'e', 'f', 'g'],
@@ -500,7 +500,7 @@ describe('Validate OBJECT schema with INVALID subject', () => {
     // @ts-expect-error for the sake of testing
     expect(validate(schema, subject).error).toStrictEqual([
       {
-        code: VALIDATE_ERROR_CODE.invalidType,
+        code: ERROR_CODE.invalidType,
         subject: invalidSubject,
         schema: schema.of.x.of,
         path: ['x', 1],
@@ -754,7 +754,7 @@ describe('Validate ARRAY schema with INVALID subject', () => {
     // @ts-expect-error for the sake of testing
     expect(validate(schema, undefinedSubj).error).toStrictEqual([
       {
-        code: VALIDATE_ERROR_CODE.invalidType,
+        code: ERROR_CODE.invalidType,
         subject: undefinedSubj,
         schema,
         path: [],
@@ -768,7 +768,7 @@ describe('Validate ARRAY schema with INVALID subject', () => {
     // @ts-expect-error for the sake of testing
     expect(validate(schema, nullSubj).error).toStrictEqual([
       {
-        code: VALIDATE_ERROR_CODE.invalidType,
+        code: ERROR_CODE.invalidType,
         subject: nullSubj,
         schema,
         path: [],
@@ -782,7 +782,7 @@ describe('Validate ARRAY schema with INVALID subject', () => {
     // @ts-expect-error for the sake of testing
     expect(validate(schema, stringSubj).error).toStrictEqual([
       {
-        code: VALIDATE_ERROR_CODE.invalidType,
+        code: ERROR_CODE.invalidType,
         subject: stringSubj,
         schema,
         path: [],
@@ -804,7 +804,7 @@ describe('Validate ARRAY schema with INVALID subject', () => {
     // @ts-expect-error for the sake of testing
     expect(validate(schema, strSubject).error).toStrictEqual([
       {
-        code: VALIDATE_ERROR_CODE.invalidType,
+        code: ERROR_CODE.invalidType,
         subject: strSubject,
         schema,
         path: [],
@@ -836,13 +836,13 @@ describe('Validate ARRAY schema with INVALID subject', () => {
     expect(validate(schema, subject).data).toBe(undefined)
     expect(validate(schema, subject).error).toStrictEqual([
       {
-        code: VALIDATE_ERROR_CODE.invalidType,
+        code: ERROR_CODE.invalidType,
         subject: invalidSubject,
         schema: schema.of,
         path: [firstInvalidIndex],
       },
       {
-        code: VALIDATE_ERROR_CODE.invalidType,
+        code: ERROR_CODE.invalidType,
         subject: invalidSubject,
         schema: schema.of,
         path: [secondInvalidIndex],
@@ -912,25 +912,25 @@ describe('Validate ARRAY schema with INVALID subject', () => {
     // @ts-expect-error for the sake of testing
     expect(validate(schema, subject).error).toStrictEqual([
       {
-        code: VALIDATE_ERROR_CODE.invalidType,
+        code: ERROR_CODE.invalidType,
         subject: invalidSubjForStr,
         schema: schema.of.of.of.of.of.x,
         path: [0, 0, 0, 0, 'x'],
       },
       {
-        code: VALIDATE_ERROR_CODE.invalidType,
+        code: ERROR_CODE.invalidType,
         subject: invalidSubjForBool,
         schema: schema.of.of.of.of.of.y,
         path: [0, 0, 0, 0, 'y'],
       },
       {
-        code: VALIDATE_ERROR_CODE.invalidType,
+        code: ERROR_CODE.invalidType,
         subject: invalidSubjForNumb,
         schema: schema.of.of.of.of.of.z.of.of.x,
         path: [0, 0, 0, 0, 'z', 1, 'x'],
       },
       {
-        code: VALIDATE_ERROR_CODE.invalidType,
+        code: ERROR_CODE.invalidType,
         subject: invalidSubjForNumb,
         schema: schema.of.of.of.of.of.z.of.of.x,
         path: [0, 0, 0, 0, 'z', 3, 'x'],

--- a/src/test/x-closure.test.ts
+++ b/src/test/x-closure.test.ts
@@ -1,5 +1,5 @@
 import { check, unknownX } from './test-utils'
-import { PARSE_ERROR_CODE, VALIDATE_ERROR_CODE } from '../error'
+import { ERROR_CODE, VALIDATE_ERROR_CODE } from '../error'
 
 import { array } from '../programmatic-schema/array'
 import { object } from '../programmatic-schema/object'
@@ -392,7 +392,7 @@ describe('X closure statically defined schema VALID', () => {
 
 describe('X closure statically defined schema INVALID', () => {
   /* Strict invalid subject/schema error shapes is tested in direct parser/validator tests */
-  const errP = [{ code: PARSE_ERROR_CODE.invalidType }]
+  const errP = [{ code: ERROR_CODE.invalidType }]
   const errV = [{ code: VALIDATE_ERROR_CODE.invalidType }]
 
   it('x: base short string optional/required schema parse/validate', () => {
@@ -1073,7 +1073,7 @@ describe('X closure programmatically defined schema VALID', () => {
 
 describe('X closure programmatically defined schema INVALID', () => {
   /* Strict invalid subject/schema error shapes is tested in direct parser/validator tests */
-  const errP = [{ code: PARSE_ERROR_CODE.invalidType }]
+  const errP = [{ code: ERROR_CODE.invalidType }]
   const errV = [{ code: VALIDATE_ERROR_CODE.invalidType }]
 
   it('x: base string optional/required schema parse/validate', () => {

--- a/src/test/x-closure.test.ts
+++ b/src/test/x-closure.test.ts
@@ -1,5 +1,5 @@
 import { check, unknownX } from './test-utils'
-import { ERROR_CODE, VALIDATE_ERROR_CODE } from '../error'
+import { ERROR_CODE } from '../error'
 
 import { array } from '../programmatic-schema/array'
 import { object } from '../programmatic-schema/object'
@@ -393,7 +393,7 @@ describe('X closure statically defined schema VALID', () => {
 describe('X closure statically defined schema INVALID', () => {
   /* Strict invalid subject/schema error shapes is tested in direct parser/validator tests */
   const errP = [{ code: ERROR_CODE.invalidType }]
-  const errV = [{ code: VALIDATE_ERROR_CODE.invalidType }]
+  const errV = [{ code: ERROR_CODE.invalidType }]
 
   it('x: base short string optional/required schema parse/validate', () => {
     const strInvSubj = 0
@@ -1074,7 +1074,7 @@ describe('X closure programmatically defined schema VALID', () => {
 describe('X closure programmatically defined schema INVALID', () => {
   /* Strict invalid subject/schema error shapes is tested in direct parser/validator tests */
   const errP = [{ code: ERROR_CODE.invalidType }]
-  const errV = [{ code: VALIDATE_ERROR_CODE.invalidType }]
+  const errV = [{ code: ERROR_CODE.invalidType }]
 
   it('x: base string optional/required schema parse/validate', () => {
     const strInvSubj = 0


### PR DESCRIPTION
fixes #10

- Remove redundant error codes
- Optimize `InvalidSubject` error construction
- Refactor default value logic at base schema parser
- FIX: general schema parser/validator doesn't check array min/max length
- DOC: add few details about InvalidSubject error shape into README.md