### PR TITLE
Parser should preserve object optional key only if it is specified in source

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -46,8 +46,25 @@ export function parse(
     const result: Record<string, unknown> = {}
 
     for (const key in schema.of) {
+      const narrowedSubj = subject as Record<string, unknown>
       const nestedSchema = schema.of[key] as Schema
-      const nestedValue = (subject as Record<string, unknown>)[key]
+
+      if (Object.prototype.hasOwnProperty.call(narrowedSubj, key) === false) {
+        if (nestedSchema.optional !== true) {
+          return left([
+            {
+              code: ERROR_CODE.invalidType,
+              path: [...(this || []), key],
+              schema,
+              subject,
+            },
+          ])
+        }
+
+        continue
+      }
+
+      const nestedValue = narrowedSubj[key]
 
       const parsed = parse.bind([...(this || []), key])(
         nestedSchema,

--- a/src/test/parse.test.ts
+++ b/src/test/parse.test.ts
@@ -232,6 +232,35 @@ describe('Parse OBJECT schema with VALID subject', () => {
     expect(parse(schema, null).right).toBe(null)
     expect(parse(schema, null).left).toBe(undefined)
   })
+
+  it('parse: should preserve specified undefined keys while parsing', () => {
+    const schema = {
+      type: 'object',
+      of: {
+        a: { type: 'string', optional: true },
+        b: { type: 'string', optional: true },
+        c: { type: 'string' },
+      },
+    } as const satisfies Schema
+
+    const sample = {
+      b: undefined,
+      c: 'cValue',
+    }
+
+    const expected = {
+      b: undefined,
+      c: 'cValue',
+    }
+
+    const either = parse(schema, sample)
+
+    if (either.left) {
+      throw Error('Not expected')
+    }
+
+    expect(either.right).toStrictEqual(expected)
+  })
 })
 
 describe('Parse OBJECT schema with INVALID subject', () => {


### PR DESCRIPTION
fixes #24