### PR TITLE
Remove usage of forEach method from parse functions

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,7 +3,6 @@ export const ERROR_CODE = {
   invalidRange: 'INVALID_RANGE',
 } as const
 
-// I found the untested structre, it's constant, why it's perseived as function?
 // prettier-ignore
 export const PARAMS_BY_SCHEMA_TYPE = {
   boolean:  new Set(['optional', 'nullable', 'brand', 'description'] as const),

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -205,7 +205,7 @@ function parseArray(
   }
 
   const result: unknown[] = []
-  let errors: InvalidSubject[] | undefined
+  let invalidSubjects: InvalidSubject[] | undefined
 
   for (let i = 0; i < subject.length; i++) {
     const nestedSchema = schema.of
@@ -215,16 +215,19 @@ function parseArray(
     const parsed = parseRecursively(updatedErrorPath, nestedSchema, nestedValue)
 
     if (parsed.error) {
-      errors = errors ?? []
-      parsed.error.forEach((err) => errors!.push(err))
+      invalidSubjects = invalidSubjects ?? []
+
+      for (const invalidSubject of parsed.error) {
+        invalidSubjects.push(invalidSubject)
+      }
       continue
     }
 
     result.push(parsed.data)
   }
 
-  if (errors?.length) {
-    return error(errors)
+  if (invalidSubjects?.length) {
+    return error(invalidSubjects)
   }
 
   if (
@@ -279,8 +282,9 @@ function parseObject(
   }
 
   const result: Record<string, unknown> = {}
-  let errors: InvalidSubject[] | undefined
+  let invalidSubjects: InvalidSubject[] | undefined
 
+  // Extra keys in the subject are ignored
   for (const key in schema.of) {
     const narrowedSubj = subject as Record<string, unknown>
     const nestedSchema = schema.of[key] as Schema
@@ -290,8 +294,11 @@ function parseObject(
     const parsed = parseRecursively(updatedErrorPath, nestedSchema, nestedValue)
 
     if (parsed.error) {
-      errors = errors ?? []
-      parsed.error.forEach((err) => errors!.push(err))
+      invalidSubjects = invalidSubjects ?? []
+
+      for (const invalidSubject of parsed.error) {
+        invalidSubjects.push(invalidSubject)
+      }
       continue
     }
 
@@ -300,8 +307,8 @@ function parseObject(
     }
   }
 
-  if (errors?.length) {
-    return error(errors)
+  if (invalidSubjects?.length) {
+    return error(invalidSubjects)
   }
 
   return data(result)
@@ -328,7 +335,7 @@ function parseRecord(
   }
 
   const result: Record<string, unknown> = {}
-  let errors: InvalidSubject[] | undefined
+  let invalidSubjects: InvalidSubject[] | undefined
 
   for (const key in subject) {
     const nestedValue = (subject as Record<string, unknown>)[key]
@@ -342,16 +349,19 @@ function parseRecord(
     const parsed = parseRecursively(updatedErrorPath, schema.of, nestedValue)
 
     if (parsed.error) {
-      errors = errors ?? []
-      parsed.error.forEach((err) => errors!.push(err))
+      invalidSubjects = invalidSubjects ?? []
+
+      for (const invalidSubject of parsed.error) {
+        invalidSubjects.push(invalidSubject)
+      }
       continue
     }
 
     result[key] = parsed.data
   }
 
-  if (errors?.length) {
-    return error(errors)
+  if (invalidSubjects?.length) {
+    return error(invalidSubjects)
   }
 
   return data(result)


### PR DESCRIPTION
This pull request refactors error handling in the parsing functions to improve code clarity and consistency. The main change is renaming the `errors` variable to `invalidSubjects` and updating how errors are accumulated in the `parseArray`, `parseObject`, and `parseRecord` functions. This makes the code easier to read and understand, with a more descriptive variable name and a clearer error collection process.

### Error handling improvements

* Renamed the `errors` variable to `invalidSubjects` in the `parseArray`, `parseObject`, and `parseRecord` functions for better clarity and consistency. [[1]](diffhunk://#diff-5440d8a745153fcd12ef76b1d6cb492751d2f997e6cde5d11234552341119c2aL208-R208) [[2]](diffhunk://#diff-5440d8a745153fcd12ef76b1d6cb492751d2f997e6cde5d11234552341119c2aL282-R287) [[3]](diffhunk://#diff-5440d8a745153fcd12ef76b1d6cb492751d2f997e6cde5d11234552341119c2aL331-R338)
* Refactored error accumulation logic: replaced use of `forEach` with explicit `for...of` loops to push errors into `invalidSubjects`, making the process more readable and less error-prone. [[1]](diffhunk://#diff-5440d8a745153fcd12ef76b1d6cb492751d2f997e6cde5d11234552341119c2aL218-R230) [[2]](diffhunk://#diff-5440d8a745153fcd12ef76b1d6cb492751d2f997e6cde5d11234552341119c2aL293-R301) [[3]](diffhunk://#diff-5440d8a745153fcd12ef76b1d6cb492751d2f997e6cde5d11234552341119c2aL345-R364)
* Updated the final error return statements to use `invalidSubjects` instead of `errors`. [[1]](diffhunk://#diff-5440d8a745153fcd12ef76b1d6cb492751d2f997e6cde5d11234552341119c2aL218-R230) [[2]](diffhunk://#diff-5440d8a745153fcd12ef76b1d6cb492751d2f997e6cde5d11234552341119c2aL303-R311) [[3]](diffhunk://#diff-5440d8a745153fcd12ef76b1d6cb492751d2f997e6cde5d11234552341119c2aL345-R364)

### Minor improvements

* Added a clarifying comment in `parseObject` noting that extra keys in the subject are ignored.
* Removed an outdated comment in `src/constants.ts` for cleaner code.