### PR TITLE
Standard schema support

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,13 @@ npm install schematox
 
 ## Features
 
-- Statically defined JSON compatible schema
-- Programmatically defined schema (struct)
-- Check defined schema correctness using non generic type "Schema"
+- Statically defined **JSON** compatible schema
+- Programmatically defined schema (**struct**, **construct**)
+- Check defined schema correctness using non generic type **Schema**
 - Ether-style error handling (no unexpected throws)
 - First-class support for branded primitives (primitive nominal types alias)
 - Construct type requirement for schema itself using exposed type generics
-
+- Support the [standard schema](https://standardschema.dev) - a common interface for TypeScript validation libraries
 
 ## Quick Start
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "schematox",
-  "version": "1.0.1",
+  "version": "1.1.0-alpha",
   "scripts": {
     "prepublishOnly": "bash release-check.sh",
     "test": "jest",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -16,3 +16,8 @@ export const PARAMS_BY_SCHEMA_TYPE = {
   tuple:    new Set(['optional', 'nullable', 'description'] as const),
   union:    new Set(['optional', 'nullable', 'description'] as const),
 } as const
+
+export const STANDARD_SCHEMA = {
+  version: 1,
+  vendor: 'schematox',
+} as const

--- a/src/tests/by-struct/array.test.ts
+++ b/src/tests/by-struct/array.test.ts
@@ -1,6 +1,8 @@
 import * as x from '../../'
 import * as fixture from '../fixtures'
 
+import type { StructSharedKeys } from '../type'
+
 describe('Type inference and parse by schema/construct/struct (foldA)', () => {
   it('required', () => {
     const schema = {
@@ -20,7 +22,7 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
     foldA: {
       const construct = x.makeStruct(schema)
 
-      /* ensure that schema/construct/struct subject types are identical */
+      /* ensure that schema/construct/struct/~standard subject types are identical */
 
       type ConstructSchemaSubj = x.Infer<typeof construct.__schema>
 
@@ -36,6 +38,13 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructSubj, ExpectedSubj>()
       x.tCh<ExpectedSubj, StructSubj>()
+
+      type StandardSubj = NonNullable<
+        (typeof struct)['~standard']['types']
+      >['output']
+
+      x.tCh<StandardSubj, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardSubj>()
 
       /* parsed either type check */
 
@@ -57,6 +66,14 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructParsed, ExpectedParsed>()
       x.tCh<ExpectedParsed, StructParsed>()
+
+      type StandardParsed = Extract<
+        ReturnType<(typeof struct)['~standard']['validate']>,
+        { value: unknown }
+      >['value']
+
+      x.tCh<StandardParsed, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardParsed>()
 
       /* runtime schema check */
 
@@ -81,6 +98,18 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
         expect(structParsed.error).toBe(undefined)
         expect(structParsed.data).toStrictEqual(subj)
+
+        const standardParsed = struct['~standard'].validate(subj)
+
+        if (standardParsed instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        if (standardParsed.issues !== undefined) {
+          throw Error('not expected')
+        }
+
+        expect(standardParsed.value).toStrictEqual(subj)
       }
     }
   })
@@ -105,7 +134,7 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
     foldA: {
       const construct = x.makeStruct(schema)
 
-      /* ensure that schema/construct/struct subject types are identical */
+      /* ensure that schema/construct/struct/~standard subject types are identical */
 
       type ConstructSchemaSubj = x.Infer<typeof construct.__schema>
 
@@ -121,6 +150,13 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructSubj, ExpectedSubj>()
       x.tCh<ExpectedSubj, StructSubj>()
+
+      type StandardSubj = NonNullable<
+        (typeof struct)['~standard']['types']
+      >['output']
+
+      x.tCh<StandardSubj, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardSubj>()
 
       /* parsed either type check */
 
@@ -142,6 +178,14 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructParsed, ExpectedParsed>()
       x.tCh<ExpectedParsed, StructParsed>()
+
+      type StandardParsed = Extract<
+        ReturnType<(typeof struct)['~standard']['validate']>,
+        { value: unknown }
+      >['value']
+
+      x.tCh<StandardParsed, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardParsed>()
 
       /* runtime schema check */
 
@@ -166,6 +210,18 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
         expect(structParsed.error).toBe(undefined)
         expect(structParsed.data).toStrictEqual(subj)
+
+        const standardParsed = struct['~standard'].validate(subj)
+
+        if (standardParsed instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        if (standardParsed.issues !== undefined) {
+          throw Error('not expected')
+        }
+
+        expect(standardParsed.value).toStrictEqual(subj)
       }
     }
   })
@@ -186,7 +242,7 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
     foldA: {
       const construct = x.makeStruct(schema)
 
-      /* ensure that schema/construct/struct subject types are identical */
+      /* ensure that schema/construct/struct/~standard subject types are identical */
 
       type ConstructSchemaSubj = x.Infer<typeof construct.__schema>
 
@@ -202,6 +258,13 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructSubj, ExpectedSubj>()
       x.tCh<ExpectedSubj, StructSubj>()
+
+      type StandardSubj = NonNullable<
+        (typeof struct)['~standard']['types']
+      >['output']
+
+      x.tCh<StandardSubj, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardSubj>()
 
       /* parsed either type check */
 
@@ -223,6 +286,14 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructParsed, ExpectedParsed>()
       x.tCh<ExpectedParsed, StructParsed>()
+
+      type StandardParsed = Extract<
+        ReturnType<(typeof struct)['~standard']['validate']>,
+        { value: unknown }
+      >['value']
+
+      x.tCh<StandardParsed, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardParsed>()
 
       /* runtime schema check */
 
@@ -247,6 +318,18 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
         expect(structParsed.error).toBe(undefined)
         expect(structParsed.data).toStrictEqual(subj)
+
+        const standardParsed = struct['~standard'].validate(subj)
+
+        if (standardParsed instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        if (standardParsed.issues !== undefined) {
+          throw Error('not expected')
+        }
+
+        expect(standardParsed.value).toStrictEqual(subj)
       }
     }
   })
@@ -270,7 +353,7 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
     foldA: {
       const construct = x.makeStruct(schema)
 
-      /* ensure that schema/construct/struct subject types are identical */
+      /* ensure that schema/construct/struct/~standard subject types are identical */
 
       type ConstructSchemaSubj = x.Infer<typeof construct.__schema>
 
@@ -286,6 +369,13 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructSubj, ExpectedSubj>()
       x.tCh<ExpectedSubj, StructSubj>()
+
+      type StandardSubj = NonNullable<
+        (typeof struct)['~standard']['types']
+      >['output']
+
+      x.tCh<StandardSubj, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardSubj>()
 
       /* parsed either type check */
 
@@ -307,6 +397,14 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructParsed, ExpectedParsed>()
       x.tCh<ExpectedParsed, StructParsed>()
+
+      type StandardParsed = Extract<
+        ReturnType<(typeof struct)['~standard']['validate']>,
+        { value: unknown }
+      >['value']
+
+      x.tCh<StandardParsed, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardParsed>()
 
       /* runtime schema check */
 
@@ -331,6 +429,18 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
         expect(structParsed.error).toBe(undefined)
         expect(structParsed.data).toStrictEqual(subj)
+
+        const standardParsed = struct['~standard'].validate(subj)
+
+        if (standardParsed instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        if (standardParsed.issues !== undefined) {
+          throw Error('not expected')
+        }
+
+        expect(standardParsed.value).toStrictEqual(subj)
       }
     }
   })
@@ -354,7 +464,7 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
     foldA: {
       const construct = x.makeStruct(schema)
 
-      /* ensure that schema/construct/struct subject types are identical */
+      /* ensure that schema/construct/struct/~standard subject types are identical */
 
       type ConstructSchemaSubj = x.Infer<typeof construct.__schema>
 
@@ -370,6 +480,13 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructSubj, ExpectedSubj>()
       x.tCh<ExpectedSubj, StructSubj>()
+
+      type StandardSubj = NonNullable<
+        (typeof struct)['~standard']['types']
+      >['output']
+
+      x.tCh<StandardSubj, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardSubj>()
 
       /* parsed either type check */
 
@@ -391,6 +508,14 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructParsed, ExpectedParsed>()
       x.tCh<ExpectedParsed, StructParsed>()
+
+      type StandardParsed = Extract<
+        ReturnType<(typeof struct)['~standard']['validate']>,
+        { value: unknown }
+      >['value']
+
+      x.tCh<StandardParsed, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardParsed>()
 
       /* runtime schema check */
 
@@ -415,6 +540,18 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
         expect(structParsed.error).toBe(undefined)
         expect(structParsed.data).toStrictEqual(subj)
+
+        const standardParsed = struct['~standard'].validate(subj)
+
+        if (standardParsed instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        if (standardParsed.issues !== undefined) {
+          throw Error('not expected')
+        }
+
+        expect(standardParsed.value).toStrictEqual(subj)
       }
     }
   })
@@ -448,7 +585,7 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
     foldA: {
       const construct = x.makeStruct(schema)
 
-      /* ensure that schema/construct/struct subject types are identical */
+      /* ensure that schema/construct/struct/~standard subject types are identical */
 
       type ConstructSchemaSubj = x.Infer<typeof construct.__schema>
 
@@ -464,6 +601,13 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructSubj, ExpectedSubj>()
       x.tCh<ExpectedSubj, StructSubj>()
+
+      type StandardSubj = NonNullable<
+        (typeof struct)['~standard']['types']
+      >['output']
+
+      x.tCh<StandardSubj, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardSubj>()
 
       /* parsed either type check */
 
@@ -485,6 +629,14 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructParsed, ExpectedParsed>()
       x.tCh<ExpectedParsed, StructParsed>()
+
+      type StandardParsed = Extract<
+        ReturnType<(typeof struct)['~standard']['validate']>,
+        { value: unknown }
+      >['value']
+
+      x.tCh<StandardParsed, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardParsed>()
 
       /* runtime schema check */
 
@@ -509,6 +661,18 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
         expect(structParsed.error).toBe(undefined)
         expect(structParsed.data).toStrictEqual(subj)
+
+        const standardParsed = struct['~standard'].validate(subj)
+
+        if (standardParsed instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        if (standardParsed.issues !== undefined) {
+          throw Error('not expected')
+        }
+
+        expect(standardParsed.value).toStrictEqual(subj)
       }
     }
   })
@@ -526,12 +690,11 @@ describe('Struct parameter keys reduction and schema immutability (foldB)', () =
     const struct = prevStruct.optional()
 
     type ExpectedKeys =
-      | '__schema'
+      | StructSharedKeys
       | 'description'
       | 'maxLength'
       | 'minLength'
       | 'nullable'
-      | 'parse'
 
     foldB: {
       const construct = x.makeStruct(schema)
@@ -585,11 +748,10 @@ describe('Struct parameter keys reduction and schema immutability (foldB)', () =
     const struct = prevStruct.nullable()
 
     type ExpectedKeys =
-      | '__schema'
+      | StructSharedKeys
       | 'description'
       | 'maxLength'
       | 'minLength'
-      | 'parse'
 
     foldB: {
       const construct = x.makeStruct(schema)
@@ -643,7 +805,7 @@ describe('Struct parameter keys reduction and schema immutability (foldB)', () =
     const prevStruct = x.array(x.boolean()).optional().nullable()
     const struct = prevStruct.minLength(schema.minLength)
 
-    type ExpectedKeys = '__schema' | 'description' | 'maxLength' | 'parse'
+    type ExpectedKeys = StructSharedKeys | 'description' | 'maxLength'
 
     foldB: {
       const construct = x.makeStruct(schema)
@@ -703,7 +865,7 @@ describe('Struct parameter keys reduction and schema immutability (foldB)', () =
 
     const struct = prevStruct.maxLength(schema.maxLength)
 
-    type ExpectedKeys = '__schema' | 'description' | 'parse'
+    type ExpectedKeys = StructSharedKeys | 'description'
 
     foldB: {
       const construct = x.makeStruct(schema)
@@ -765,7 +927,7 @@ describe('Struct parameter keys reduction and schema immutability (foldB)', () =
 
     const struct = prevStruct.description(schema.description)
 
-    type ExpectedKeys = '__schema' | 'parse'
+    type ExpectedKeys = StructSharedKeys
 
     foldB: {
       const construct = x.makeStruct(schema)
@@ -827,7 +989,7 @@ describe('Struct parameter keys reduction and schema immutability (foldB)', () =
 
     const struct = prevStruct.optional()
 
-    type ExpectedKeys = '__schema' | 'parse'
+    type ExpectedKeys = StructSharedKeys
 
     foldB: {
       const construct = x.makeStruct(schema)
@@ -905,6 +1067,16 @@ describe('ERROR_CODE.invalidType (foldC, foldE)', () => {
           expect(parsedSchema.error).toStrictEqual(expectedError)
           expect(parsedConstruct.error).toStrictEqual(expectedError)
           expect(parsedStruct.error).toStrictEqual(expectedError)
+
+          const parsedStandard = struct['~standard'].validate(subject)
+
+          if (parsedStandard instanceof Promise) {
+            throw Error('Not expected')
+          }
+
+          expect(parsedStandard.issues).toStrictEqual([
+            { message: x.ERROR_CODE.invalidType, path: [] },
+          ])
         }
       }
     }
@@ -956,6 +1128,16 @@ describe('ERROR_CODE.invalidType (foldC, foldE)', () => {
         expect(parsedSchema.error).toStrictEqual(expectedError)
         expect(parsedConstruct.error).toStrictEqual(expectedError)
         expect(parsedStruct.error).toStrictEqual(expectedError)
+
+        const parsedStandard = struct['~standard'].validate(subject)
+
+        if (parsedStandard instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        expect(parsedStandard.issues).toStrictEqual([
+          { path, message: x.ERROR_CODE.invalidType },
+        ])
       }
     }
   })
@@ -1028,6 +1210,16 @@ describe('ERROR_CODE.invalidRange (foldD)', () => {
         expect(parsedSchema.error).toStrictEqual(expectedError)
         expect(parsedConstruct.error).toStrictEqual(expectedError)
         expect(parsedStruct.error).toStrictEqual(expectedError)
+
+        const parsedStandard = struct['~standard'].validate(subject)
+
+        if (parsedStandard instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        expect(parsedStandard.issues).toStrictEqual([
+          { message: x.ERROR_CODE.invalidRange, path: [] },
+        ])
       }
     }
   })
@@ -1062,6 +1254,16 @@ describe('ERROR_CODE.invalidRange (foldD)', () => {
         expect(parsedSchema.error).toStrictEqual(expectedError)
         expect(parsedConstruct.error).toStrictEqual(expectedError)
         expect(parsedStruct.error).toStrictEqual(expectedError)
+
+        const parsedStandard = struct['~standard'].validate(subject)
+
+        if (parsedStandard instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        expect(parsedStandard.issues).toStrictEqual([
+          { message: x.ERROR_CODE.invalidRange, path: [] },
+        ])
       }
     }
   })
@@ -1101,6 +1303,16 @@ describe('ERROR_CODE.invalidRange (foldD)', () => {
         expect(parsedSchema.error).toStrictEqual(expectedError)
         expect(parsedConstruct.error).toStrictEqual(expectedError)
         expect(parsedStruct.error).toStrictEqual(expectedError)
+
+        const parsedStandard = struct['~standard'].validate(subject)
+
+        if (parsedStandard instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        expect(parsedStandard.issues).toStrictEqual([
+          { message: x.ERROR_CODE.invalidRange, path: [] },
+        ])
       }
     }
   })
@@ -1140,7 +1352,7 @@ describe('Compound schema specifics (foldA)', () => {
     foldA: {
       const construct = x.makeStruct(schema)
 
-      /* ensure that schema/construct/struct subject types are identical */
+      /* ensure that schema/construct/struct/~standard subject types are identical */
 
       type ConstructSchemaSubj = x.Infer<typeof construct.__schema>
 
@@ -1156,6 +1368,13 @@ describe('Compound schema specifics (foldA)', () => {
 
       x.tCh<StructSubj, ExpectedSubj>()
       x.tCh<ExpectedSubj, StructSubj>()
+
+      type StandardSubj = NonNullable<
+        (typeof struct)['~standard']['types']
+      >['output']
+
+      x.tCh<StandardSubj, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardSubj>()
 
       /* parsed either type check */
 
@@ -1177,6 +1396,14 @@ describe('Compound schema specifics (foldA)', () => {
 
       x.tCh<StructParsed, ExpectedParsed>()
       x.tCh<ExpectedParsed, StructParsed>()
+
+      type StandardParsed = Extract<
+        ReturnType<(typeof struct)['~standard']['validate']>,
+        { value: unknown }
+      >['value']
+
+      x.tCh<StandardParsed, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardParsed>()
 
       /* runtime schema check */
 
@@ -1201,6 +1428,18 @@ describe('Compound schema specifics (foldA)', () => {
 
         expect(structParsed.error).toBe(undefined)
         expect(structParsed.data).toStrictEqual(subj)
+
+        const standardParsed = struct['~standard'].validate(subj)
+
+        if (standardParsed instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        if (standardParsed.issues !== undefined) {
+          throw Error('not expected')
+        }
+
+        expect(standardParsed.value).toStrictEqual(subj)
       }
     }
   })
@@ -1232,7 +1471,7 @@ describe('Compound schema specifics (foldA)', () => {
     foldA: {
       const construct = x.makeStruct(schema)
 
-      /* ensure that schema/construct/struct subject types are identical */
+      /* ensure that schema/construct/struct/~standard subject types are identical */
 
       type ConstructSchemaSubj = x.Infer<typeof construct.__schema>
 
@@ -1248,6 +1487,13 @@ describe('Compound schema specifics (foldA)', () => {
 
       x.tCh<StructSubj, ExpectedSubj>()
       x.tCh<ExpectedSubj, StructSubj>()
+
+      type StandardSubj = NonNullable<
+        (typeof struct)['~standard']['types']
+      >['output']
+
+      x.tCh<StandardSubj, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardSubj>()
 
       /* parsed either type check */
 
@@ -1269,6 +1515,14 @@ describe('Compound schema specifics (foldA)', () => {
 
       x.tCh<StructParsed, ExpectedParsed>()
       x.tCh<ExpectedParsed, StructParsed>()
+
+      type StandardParsed = Extract<
+        ReturnType<(typeof struct)['~standard']['validate']>,
+        { value: unknown }
+      >['value']
+
+      x.tCh<StandardParsed, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardParsed>()
 
       /* runtime schema check */
 
@@ -1293,6 +1547,18 @@ describe('Compound schema specifics (foldA)', () => {
 
         expect(structParsed.error).toBe(undefined)
         expect(structParsed.data).toStrictEqual(subj)
+
+        const standardParsed = struct['~standard'].validate(subj)
+
+        if (standardParsed instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        if (standardParsed.issues !== undefined) {
+          throw Error('not expected')
+        }
+
+        expect(standardParsed.value).toStrictEqual(subj)
       }
     }
   })
@@ -1324,7 +1590,7 @@ describe('Compound schema specifics (foldA)', () => {
     foldA: {
       const construct = x.makeStruct(schema)
 
-      /* ensure that schema/construct/struct subject types are identical */
+      /* ensure that schema/construct/struct/~standard subject types are identical */
 
       type ConstructSchemaSubj = x.Infer<typeof construct.__schema>
 
@@ -1340,6 +1606,13 @@ describe('Compound schema specifics (foldA)', () => {
 
       x.tCh<StructSubj, ExpectedSubj>()
       x.tCh<ExpectedSubj, StructSubj>()
+
+      type StandardSubj = NonNullable<
+        (typeof struct)['~standard']['types']
+      >['output']
+
+      x.tCh<StandardSubj, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardSubj>()
 
       /* parsed either type check */
 
@@ -1361,6 +1634,14 @@ describe('Compound schema specifics (foldA)', () => {
 
       x.tCh<StructParsed, ExpectedParsed>()
       x.tCh<ExpectedParsed, StructParsed>()
+
+      type StandardParsed = Extract<
+        ReturnType<(typeof struct)['~standard']['validate']>,
+        { value: unknown }
+      >['value']
+
+      x.tCh<StandardParsed, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardParsed>()
 
       /* runtime schema check */
 
@@ -1385,6 +1666,18 @@ describe('Compound schema specifics (foldA)', () => {
 
         expect(structParsed.error).toBe(undefined)
         expect(structParsed.data).toStrictEqual(subj)
+
+        const standardParsed = struct['~standard'].validate(subj)
+
+        if (standardParsed instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        if (standardParsed.issues !== undefined) {
+          throw Error('not expected')
+        }
+
+        expect(standardParsed.value).toStrictEqual(subj)
       }
     }
   })

--- a/src/tests/by-struct/boolean.test.ts
+++ b/src/tests/by-struct/boolean.test.ts
@@ -1,6 +1,8 @@
 import * as x from '../../'
 import * as fixture from '../fixtures'
 
+import type { StructSharedKeys } from '../type'
+
 describe('Type inference and parse by schema/construct/struct (foldA)', () => {
   it('required', () => {
     const schema = { type: 'boolean' } as const satisfies x.Schema
@@ -13,7 +15,7 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
     foldA: {
       const construct = x.makeStruct(schema)
 
-      /* ensure that schema/construct/struct subject types are identical */
+      /* ensure that schema/construct/struct/~standard subject types are identical */
 
       type ConstructSchemaSubj = x.Infer<typeof construct.__schema>
 
@@ -29,6 +31,13 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructSubj, ExpectedSubj>()
       x.tCh<ExpectedSubj, StructSubj>()
+
+      type StandardSubj = NonNullable<
+        (typeof struct)['~standard']['types']
+      >['output']
+
+      x.tCh<StandardSubj, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardSubj>()
 
       /* parsed either type check */
 
@@ -50,6 +59,14 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructParsed, ExpectedParsed>()
       x.tCh<ExpectedParsed, StructParsed>()
+
+      type StandardParsed = Extract<
+        ReturnType<(typeof struct)['~standard']['validate']>,
+        { value: unknown }
+      >['value']
+
+      x.tCh<StandardParsed, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardParsed>()
 
       /* runtime schema check */
 
@@ -74,6 +91,18 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
         expect(structParsed.error).toBe(undefined)
         expect(structParsed.data).toStrictEqual(subj)
+
+        const standardParsed = struct['~standard'].validate(subj)
+
+        if (standardParsed instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        if (standardParsed.issues !== undefined) {
+          throw Error('not expected')
+        }
+
+        expect(standardParsed.value).toStrictEqual(subj)
       }
     }
   })
@@ -92,7 +121,7 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
     foldA: {
       const construct = x.makeStruct(schema)
 
-      /* ensure that schema/construct/struct subject types are identical */
+      /* ensure that schema/construct/struct/~standard subject types are identical */
 
       type ConstructSchemaSubj = x.Infer<typeof construct.__schema>
 
@@ -108,6 +137,13 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructSubj, ExpectedSubj>()
       x.tCh<ExpectedSubj, StructSubj>()
+
+      type StandardSubj = NonNullable<
+        (typeof struct)['~standard']['types']
+      >['output']
+
+      x.tCh<StandardSubj, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardSubj>()
 
       /* parsed either type check */
 
@@ -129,6 +165,14 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructParsed, ExpectedParsed>()
       x.tCh<ExpectedParsed, StructParsed>()
+
+      type StandardParsed = Extract<
+        ReturnType<(typeof struct)['~standard']['validate']>,
+        { value: unknown }
+      >['value']
+
+      x.tCh<StandardParsed, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardParsed>()
 
       /* runtime schema check */
 
@@ -153,6 +197,18 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
         expect(structParsed.error).toBe(undefined)
         expect(structParsed.data).toStrictEqual(subj)
+
+        const standardParsed = struct['~standard'].validate(subj)
+
+        if (standardParsed instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        if (standardParsed.issues !== undefined) {
+          throw Error('not expected')
+        }
+
+        expect(standardParsed.value).toStrictEqual(subj)
       }
     }
   })
@@ -171,7 +227,7 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
     foldA: {
       const construct = x.makeStruct(schema)
 
-      /* ensure that schema/construct/struct subject types are identical */
+      /* ensure that schema/construct/struct/~standard subject types are identical */
 
       type ConstructSchemaSubj = x.Infer<typeof construct.__schema>
 
@@ -187,6 +243,13 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructSubj, ExpectedSubj>()
       x.tCh<ExpectedSubj, StructSubj>()
+
+      type StandardSubj = NonNullable<
+        (typeof struct)['~standard']['types']
+      >['output']
+
+      x.tCh<StandardSubj, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardSubj>()
 
       /* parsed either type check */
 
@@ -208,6 +271,14 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructParsed, ExpectedParsed>()
       x.tCh<ExpectedParsed, StructParsed>()
+
+      type StandardParsed = Extract<
+        ReturnType<(typeof struct)['~standard']['validate']>,
+        { value: unknown }
+      >['value']
+
+      x.tCh<StandardParsed, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardParsed>()
 
       /* runtime schema check */
 
@@ -232,6 +303,18 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
         expect(structParsed.error).toBe(undefined)
         expect(structParsed.data).toStrictEqual(subj)
+
+        const standardParsed = struct['~standard'].validate(subj)
+
+        if (standardParsed instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        if (standardParsed.issues !== undefined) {
+          throw Error('not expected')
+        }
+
+        expect(standardParsed.value).toStrictEqual(subj)
       }
     }
   })
@@ -251,7 +334,7 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
     foldA: {
       const construct = x.makeStruct(schema)
 
-      /* ensure that schema/construct/struct subject types are identical */
+      /* ensure that schema/construct/struct/~standard subject types are identical */
 
       type ConstructSchemaSubj = x.Infer<typeof construct.__schema>
 
@@ -267,6 +350,13 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructSubj, ExpectedSubj>()
       x.tCh<ExpectedSubj, StructSubj>()
+
+      type StandardSubj = NonNullable<
+        (typeof struct)['~standard']['types']
+      >['output']
+
+      x.tCh<StandardSubj, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardSubj>()
 
       /* parsed either type check */
 
@@ -288,6 +378,14 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructParsed, ExpectedParsed>()
       x.tCh<ExpectedParsed, StructParsed>()
+
+      type StandardParsed = Extract<
+        ReturnType<(typeof struct)['~standard']['validate']>,
+        { value: unknown }
+      >['value']
+
+      x.tCh<StandardParsed, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardParsed>()
 
       /* runtime schema check */
 
@@ -312,6 +410,18 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
         expect(structParsed.error).toBe(undefined)
         expect(structParsed.data).toStrictEqual(subj)
+
+        const standardParsed = struct['~standard'].validate(subj)
+
+        if (standardParsed instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        if (standardParsed.issues !== undefined) {
+          throw Error('not expected')
+        }
+
+        expect(standardParsed.value).toStrictEqual(subj)
       }
     }
   })
@@ -327,12 +437,7 @@ describe('Struct parameter keys reduction and schema immutability (foldB)', () =
     const prevStruct = x.boolean()
     const struct = prevStruct.optional()
 
-    type ExpectedKeys =
-      | 'brand'
-      | 'nullable'
-      | 'description'
-      | '__schema'
-      | 'parse'
+    type ExpectedKeys = StructSharedKeys | 'brand' | 'nullable' | 'description'
 
     foldB: {
       const construct = x.makeStruct(schema)
@@ -384,7 +489,7 @@ describe('Struct parameter keys reduction and schema immutability (foldB)', () =
     const prevStruct = x.boolean().optional()
     const struct = prevStruct.nullable()
 
-    type ExpectedKeys = 'brand' | 'description' | '__schema' | 'parse'
+    type ExpectedKeys = StructSharedKeys | 'brand' | 'description'
 
     foldB: {
       const construct = x.makeStruct(schema)
@@ -437,7 +542,7 @@ describe('Struct parameter keys reduction and schema immutability (foldB)', () =
     const prevStruct = x.boolean().optional().nullable()
     const struct = prevStruct.brand('x', 'y')
 
-    type ExpectedKeys = 'description' | '__schema' | 'parse'
+    type ExpectedKeys = StructSharedKeys | 'description'
 
     foldB: {
       const construct = x.makeStruct(schema)
@@ -491,7 +596,7 @@ describe('Struct parameter keys reduction and schema immutability (foldB)', () =
     const prevStruct = x.boolean().optional().nullable().brand('x', 'y')
     const struct = prevStruct.description('x')
 
-    type ExpectedKeys = '__schema' | 'parse'
+    type ExpectedKeys = StructSharedKeys
 
     foldB: {
       const construct = x.makeStruct(schema)
@@ -545,7 +650,7 @@ describe('Struct parameter keys reduction and schema immutability (foldB)', () =
     const prevStruct = x.boolean().description('x').brand('x', 'y').nullable()
     const struct = prevStruct.optional()
 
-    type ExpectedKeys = '__schema' | 'parse'
+    type ExpectedKeys = StructSharedKeys
 
     foldB: {
       const construct = x.makeStruct(schema)
@@ -619,6 +724,16 @@ describe('ERROR_CODE.invalidType (foldC)', () => {
           expect(parsedSchema.error).toStrictEqual(expectedError)
           expect(parsedConstruct.error).toStrictEqual(expectedError)
           expect(parsedStruct.error).toStrictEqual(expectedError)
+
+          const parsedStandard = struct['~standard'].validate(subject)
+
+          if (parsedStandard instanceof Promise) {
+            throw Error('Not expected')
+          }
+
+          expect(parsedStandard.issues).toStrictEqual([
+            { message: x.ERROR_CODE.invalidType, path: [] },
+          ])
         }
       }
     }

--- a/src/tests/by-struct/literal.test.ts
+++ b/src/tests/by-struct/literal.test.ts
@@ -1,6 +1,8 @@
 import * as x from '../../'
 import * as fixture from '../fixtures'
 
+import type { StructSharedKeys } from '../type'
+
 describe('Type inference and parse by schema/construct/struct (foldA)', () => {
   it('required', () => {
     const schema = { type: 'literal', of: 'x' } as const satisfies x.Schema
@@ -13,7 +15,7 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
     foldA: {
       const construct = x.makeStruct(schema)
 
-      /* ensure that schema/construct/struct subject types are identical */
+      /* ensure that schema/construct/struct/~standard subject types are identical */
 
       type ConstructSchemaSubj = x.Infer<typeof construct.__schema>
 
@@ -29,6 +31,13 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructSubj, ExpectedSubj>()
       x.tCh<ExpectedSubj, StructSubj>()
+
+      type StandardSubj = NonNullable<
+        (typeof struct)['~standard']['types']
+      >['output']
+
+      x.tCh<StandardSubj, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardSubj>()
 
       /* parsed either type check */
 
@@ -50,6 +59,14 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructParsed, ExpectedParsed>()
       x.tCh<ExpectedParsed, StructParsed>()
+
+      type StandardParsed = Extract<
+        ReturnType<(typeof struct)['~standard']['validate']>,
+        { value: unknown }
+      >['value']
+
+      x.tCh<StandardParsed, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardParsed>()
 
       /* runtime schema check */
 
@@ -74,6 +91,18 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
         expect(structParsed.error).toBe(undefined)
         expect(structParsed.data).toStrictEqual(subj)
+
+        const standardParsed = struct['~standard'].validate(subj)
+
+        if (standardParsed instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        if (standardParsed.issues !== undefined) {
+          throw Error('not expected')
+        }
+
+        expect(standardParsed.value).toStrictEqual(subj)
       }
     }
   })
@@ -94,7 +123,7 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
     foldA: {
       const construct = x.makeStruct(schema)
 
-      /* ensure that schema/construct/struct subject types are identical */
+      /* ensure that schema/construct/struct/~standard subject types are identical */
 
       type ConstructSchemaSubj = x.Infer<typeof construct.__schema>
 
@@ -110,6 +139,13 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructSubj, ExpectedSubj>()
       x.tCh<ExpectedSubj, StructSubj>()
+
+      type StandardSubj = NonNullable<
+        (typeof struct)['~standard']['types']
+      >['output']
+
+      x.tCh<StandardSubj, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardSubj>()
 
       /* parsed either type check */
 
@@ -131,6 +167,14 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructParsed, ExpectedParsed>()
       x.tCh<ExpectedParsed, StructParsed>()
+
+      type StandardParsed = Extract<
+        ReturnType<(typeof struct)['~standard']['validate']>,
+        { value: unknown }
+      >['value']
+
+      x.tCh<StandardParsed, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardParsed>()
 
       /* runtime schema check */
 
@@ -155,6 +199,18 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
         expect(structParsed.error).toBe(undefined)
         expect(structParsed.data).toStrictEqual(subj)
+
+        const standardParsed = struct['~standard'].validate(subj)
+
+        if (standardParsed instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        if (standardParsed.issues !== undefined) {
+          throw Error('not expected')
+        }
+
+        expect(standardParsed.value).toStrictEqual(subj)
       }
     }
   })
@@ -175,7 +231,7 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
     foldA: {
       const construct = x.makeStruct(schema)
 
-      /* ensure that schema/construct/struct subject types are identical */
+      /* ensure that schema/construct/struct/~standard subject types are identical */
 
       type ConstructSchemaSubj = x.Infer<typeof construct.__schema>
 
@@ -191,6 +247,13 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructSubj, ExpectedSubj>()
       x.tCh<ExpectedSubj, StructSubj>()
+
+      type StandardSubj = NonNullable<
+        (typeof struct)['~standard']['types']
+      >['output']
+
+      x.tCh<StandardSubj, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardSubj>()
 
       /* parsed either type check */
 
@@ -212,6 +275,14 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructParsed, ExpectedParsed>()
       x.tCh<ExpectedParsed, StructParsed>()
+
+      type StandardParsed = Extract<
+        ReturnType<(typeof struct)['~standard']['validate']>,
+        { value: unknown }
+      >['value']
+
+      x.tCh<StandardParsed, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardParsed>()
 
       /* runtime schema check */
 
@@ -236,6 +307,18 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
         expect(structParsed.error).toBe(undefined)
         expect(structParsed.data).toStrictEqual(subj)
+
+        const standardParsed = struct['~standard'].validate(subj)
+
+        if (standardParsed instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        if (standardParsed.issues !== undefined) {
+          throw Error('not expected')
+        }
+
+        expect(standardParsed.value).toStrictEqual(subj)
       }
     }
   })
@@ -256,7 +339,7 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
     foldA: {
       const construct = x.makeStruct(schema)
 
-      /* ensure that schema/construct/struct subject types are identical */
+      /* ensure that schema/construct/struct/~standard subject types are identical */
 
       type ConstructSchemaSubj = x.Infer<typeof construct.__schema>
 
@@ -272,6 +355,13 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructSubj, ExpectedSubj>()
       x.tCh<ExpectedSubj, StructSubj>()
+
+      type StandardSubj = NonNullable<
+        (typeof struct)['~standard']['types']
+      >['output']
+
+      x.tCh<StandardSubj, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardSubj>()
 
       /* parsed either type check */
 
@@ -293,6 +383,14 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructParsed, ExpectedParsed>()
       x.tCh<ExpectedParsed, StructParsed>()
+
+      type StandardParsed = Extract<
+        ReturnType<(typeof struct)['~standard']['validate']>,
+        { value: unknown }
+      >['value']
+
+      x.tCh<StandardParsed, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardParsed>()
 
       /* runtime schema check */
 
@@ -317,6 +415,18 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
         expect(structParsed.error).toBe(undefined)
         expect(structParsed.data).toStrictEqual(subj)
+
+        const standardParsed = struct['~standard'].validate(subj)
+
+        if (standardParsed instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        if (standardParsed.issues !== undefined) {
+          throw Error('not expected')
+        }
+
+        expect(standardParsed.value).toStrictEqual(subj)
       }
     }
   })
@@ -333,12 +443,7 @@ describe('Struct parameter keys reduction and schema immutability (foldB)', () =
     const prevStruct = x.literal(0)
     const struct = prevStruct.optional()
 
-    type ExpectedKeys =
-      | 'brand'
-      | 'nullable'
-      | 'description'
-      | '__schema'
-      | 'parse'
+    type ExpectedKeys = StructSharedKeys | 'brand' | 'nullable' | 'description'
 
     foldB: {
       const construct = x.makeStruct(schema)
@@ -391,7 +496,7 @@ describe('Struct parameter keys reduction and schema immutability (foldB)', () =
     const prevStruct = x.literal(0).optional()
     const struct = prevStruct.nullable()
 
-    type ExpectedKeys = 'brand' | 'description' | '__schema' | 'parse'
+    type ExpectedKeys = StructSharedKeys | 'brand' | 'description'
 
     foldB: {
       const construct = x.makeStruct(schema)
@@ -445,7 +550,7 @@ describe('Struct parameter keys reduction and schema immutability (foldB)', () =
     const prevStruct = x.literal(0).optional().nullable()
     const struct = prevStruct.brand('x', 'y')
 
-    type ExpectedKeys = 'description' | '__schema' | 'parse'
+    type ExpectedKeys = StructSharedKeys | 'description'
 
     foldB: {
       const construct = x.makeStruct(schema)
@@ -500,7 +605,7 @@ describe('Struct parameter keys reduction and schema immutability (foldB)', () =
     const prevStruct = x.literal(0).optional().nullable().brand('x', 'y')
     const struct = prevStruct.description('x')
 
-    type ExpectedKeys = '__schema' | 'parse'
+    type ExpectedKeys = StructSharedKeys
 
     foldB: {
       const construct = x.makeStruct(schema)
@@ -555,7 +660,7 @@ describe('Struct parameter keys reduction and schema immutability (foldB)', () =
     const prevStruct = x.literal(0).description('x').brand('x', 'y').nullable()
     const struct = prevStruct.optional()
 
-    type ExpectedKeys = '__schema' | 'parse'
+    type ExpectedKeys = StructSharedKeys
 
     foldB: {
       const construct = x.makeStruct(schema)
@@ -633,6 +738,16 @@ describe('ERROR_CODE.invalidType (foldC)', () => {
           expect(parsedSchema.error).toStrictEqual(expectedError)
           expect(parsedConstruct.error).toStrictEqual(expectedError)
           expect(parsedStruct.error).toStrictEqual(expectedError)
+
+          const parsedStandard = struct['~standard'].validate(subject)
+
+          if (parsedStandard instanceof Promise) {
+            throw Error('Not expected')
+          }
+
+          expect(parsedStandard.issues).toStrictEqual([
+            { message: x.ERROR_CODE.invalidType, path: [] },
+          ])
         }
       }
     }

--- a/src/tests/by-struct/number.test.ts
+++ b/src/tests/by-struct/number.test.ts
@@ -1,6 +1,8 @@
 import * as x from '../../'
 import * as fixture from '../fixtures'
 
+import type { StructSharedKeys } from '../type'
+
 describe('Type inference and parse by schema/construct/struct (foldA)', () => {
   it('required', () => {
     const schema = { type: 'number' } as const satisfies x.Schema
@@ -13,7 +15,7 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
     foldA: {
       const construct = x.makeStruct(schema)
 
-      /* ensure that schema/construct/struct subject types are identical */
+      /* ensure that schema/construct/struct/~standard subject types are identical */
 
       type ConstructSchemaSubj = x.Infer<typeof construct.__schema>
 
@@ -29,6 +31,13 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructSubj, ExpectedSubj>()
       x.tCh<ExpectedSubj, StructSubj>()
+
+      type StandardSubj = NonNullable<
+        (typeof struct)['~standard']['types']
+      >['output']
+
+      x.tCh<StandardSubj, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardSubj>()
 
       /* parsed either type check */
 
@@ -50,6 +59,14 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructParsed, ExpectedParsed>()
       x.tCh<ExpectedParsed, StructParsed>()
+
+      type StandardParsed = Extract<
+        ReturnType<(typeof struct)['~standard']['validate']>,
+        { value: unknown }
+      >['value']
+
+      x.tCh<StandardParsed, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardParsed>()
 
       /* runtime schema check */
 
@@ -74,6 +91,18 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
         expect(structParsed.error).toBe(undefined)
         expect(structParsed.data).toStrictEqual(subj)
+
+        const standardParsed = struct['~standard'].validate(subj)
+
+        if (standardParsed instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        if (standardParsed.issues !== undefined) {
+          throw Error('not expected')
+        }
+
+        expect(standardParsed.value).toStrictEqual(subj)
       }
     }
   })
@@ -96,7 +125,7 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
     foldA: {
       const construct = x.makeStruct(schema)
 
-      /* ensure that schema/construct/struct subject types are identical */
+      /* ensure that schema/construct/struct/~standard subject types are identical */
 
       type ConstructSchemaSubj = x.Infer<typeof construct.__schema>
 
@@ -112,6 +141,13 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructSubj, ExpectedSubj>()
       x.tCh<ExpectedSubj, StructSubj>()
+
+      type StandardSubj = NonNullable<
+        (typeof struct)['~standard']['types']
+      >['output']
+
+      x.tCh<StandardSubj, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardSubj>()
 
       /* parsed either type check */
 
@@ -133,6 +169,14 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructParsed, ExpectedParsed>()
       x.tCh<ExpectedParsed, StructParsed>()
+
+      type StandardParsed = Extract<
+        ReturnType<(typeof struct)['~standard']['validate']>,
+        { value: unknown }
+      >['value']
+
+      x.tCh<StandardParsed, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardParsed>()
 
       /* runtime schema check */
 
@@ -157,6 +201,18 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
         expect(structParsed.error).toBe(undefined)
         expect(structParsed.data).toStrictEqual(subj)
+
+        const standardParsed = struct['~standard'].validate(subj)
+
+        if (standardParsed instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        if (standardParsed.issues !== undefined) {
+          throw Error('not expected')
+        }
+
+        expect(standardParsed.value).toStrictEqual(subj)
       }
     }
   })
@@ -179,7 +235,7 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
     foldA: {
       const construct = x.makeStruct(schema)
 
-      /* ensure that schema/construct/struct subject types are identical */
+      /* ensure that schema/construct/struct/~standard subject types are identical */
 
       type ConstructSchemaSubj = x.Infer<typeof construct.__schema>
 
@@ -195,6 +251,13 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructSubj, ExpectedSubj>()
       x.tCh<ExpectedSubj, StructSubj>()
+
+      type StandardSubj = NonNullable<
+        (typeof struct)['~standard']['types']
+      >['output']
+
+      x.tCh<StandardSubj, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardSubj>()
 
       /* parsed either type check */
 
@@ -216,6 +279,14 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructParsed, ExpectedParsed>()
       x.tCh<ExpectedParsed, StructParsed>()
+
+      type StandardParsed = Extract<
+        ReturnType<(typeof struct)['~standard']['validate']>,
+        { value: unknown }
+      >['value']
+
+      x.tCh<StandardParsed, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardParsed>()
 
       /* runtime schema check */
 
@@ -240,6 +311,18 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
         expect(structParsed.error).toBe(undefined)
         expect(structParsed.data).toStrictEqual(subj)
+
+        const standardParsed = struct['~standard'].validate(subj)
+
+        if (standardParsed instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        if (standardParsed.issues !== undefined) {
+          throw Error('not expected')
+        }
+
+        expect(standardParsed.value).toStrictEqual(subj)
       }
     }
   })
@@ -259,7 +342,7 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
     foldA: {
       const construct = x.makeStruct(schema)
 
-      /* ensure that schema/construct/struct subject types are identical */
+      /* ensure that schema/construct/struct/~standard subject types are identical */
 
       type ConstructSchemaSubj = x.Infer<typeof construct.__schema>
 
@@ -275,6 +358,13 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructSubj, ExpectedSubj>()
       x.tCh<ExpectedSubj, StructSubj>()
+
+      type StandardSubj = NonNullable<
+        (typeof struct)['~standard']['types']
+      >['output']
+
+      x.tCh<StandardSubj, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardSubj>()
 
       /* parsed either type check */
 
@@ -296,6 +386,14 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructParsed, ExpectedParsed>()
       x.tCh<ExpectedParsed, StructParsed>()
+
+      type StandardParsed = Extract<
+        ReturnType<(typeof struct)['~standard']['validate']>,
+        { value: unknown }
+      >['value']
+
+      x.tCh<StandardParsed, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardParsed>()
 
       /* runtime schema check */
 
@@ -320,6 +418,18 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
         expect(structParsed.error).toBe(undefined)
         expect(structParsed.data).toStrictEqual(subj)
+
+        const standardParsed = struct['~standard'].validate(subj)
+
+        if (standardParsed instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        if (standardParsed.issues !== undefined) {
+          throw Error('not expected')
+        }
+
+        expect(standardParsed.value).toStrictEqual(subj)
       }
     }
   })
@@ -339,7 +449,7 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
     foldA: {
       const construct = x.makeStruct(schema)
 
-      /* ensure that schema/construct/struct subject types are identical */
+      /* ensure that schema/construct/struct/~standard subject types are identical */
 
       type ConstructSchemaSubj = x.Infer<typeof construct.__schema>
 
@@ -355,6 +465,13 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructSubj, ExpectedSubj>()
       x.tCh<ExpectedSubj, StructSubj>()
+
+      type StandardSubj = NonNullable<
+        (typeof struct)['~standard']['types']
+      >['output']
+
+      x.tCh<StandardSubj, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardSubj>()
 
       /* parsed either type check */
 
@@ -376,6 +493,14 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructParsed, ExpectedParsed>()
       x.tCh<ExpectedParsed, StructParsed>()
+
+      type StandardParsed = Extract<
+        ReturnType<(typeof struct)['~standard']['validate']>,
+        { value: unknown }
+      >['value']
+
+      x.tCh<StandardParsed, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardParsed>()
 
       /* runtime schema check */
 
@@ -400,6 +525,18 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
         expect(structParsed.error).toBe(undefined)
         expect(structParsed.data).toStrictEqual(subj)
+
+        const standardParsed = struct['~standard'].validate(subj)
+
+        if (standardParsed instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        if (standardParsed.issues !== undefined) {
+          throw Error('not expected')
+        }
+
+        expect(standardParsed.value).toStrictEqual(subj)
       }
     }
   })
@@ -427,7 +564,7 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
     foldA: {
       const construct = x.makeStruct(schema)
 
-      /* ensure that schema/construct/struct subject types are identical */
+      /* ensure that schema/construct/struct/~standard subject types are identical */
 
       type ConstructSchemaSubj = x.Infer<typeof construct.__schema>
 
@@ -443,6 +580,13 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructSubj, ExpectedSubj>()
       x.tCh<ExpectedSubj, StructSubj>()
+
+      type StandardSubj = NonNullable<
+        (typeof struct)['~standard']['types']
+      >['output']
+
+      x.tCh<StandardSubj, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardSubj>()
 
       /* parsed either type check */
 
@@ -464,6 +608,14 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructParsed, ExpectedParsed>()
       x.tCh<ExpectedParsed, StructParsed>()
+
+      type StandardParsed = Extract<
+        ReturnType<(typeof struct)['~standard']['validate']>,
+        { value: unknown }
+      >['value']
+
+      x.tCh<StandardParsed, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardParsed>()
 
       /* runtime schema check */
 
@@ -488,6 +640,18 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
         expect(structParsed.error).toBe(undefined)
         expect(structParsed.data).toStrictEqual(subj)
+
+        const standardParsed = struct['~standard'].validate(subj)
+
+        if (standardParsed instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        if (standardParsed.issues !== undefined) {
+          throw Error('not expected')
+        }
+
+        expect(standardParsed.value).toStrictEqual(subj)
       }
     }
   })
@@ -504,13 +668,12 @@ describe('Struct parameter keys reduction and schema immutability (foldB)', () =
     const struct = prevStruct.optional()
 
     type ExpectedKeys =
-      | '__schema'
+      | StructSharedKeys
       | 'brand'
       | 'description'
       | 'max'
       | 'min'
       | 'nullable'
-      | 'parse'
 
     foldB: {
       const construct = x.makeStruct(schema)
@@ -563,12 +726,11 @@ describe('Struct parameter keys reduction and schema immutability (foldB)', () =
     const struct = prevStruct.nullable()
 
     type ExpectedKeys =
-      | '__schema'
+      | StructSharedKeys
       | 'brand'
       | 'description'
       | 'max'
       | 'min'
-      | 'parse'
 
     foldB: {
       const construct = x.makeStruct(schema)
@@ -621,7 +783,7 @@ describe('Struct parameter keys reduction and schema immutability (foldB)', () =
     const prevStruct = x.number().optional().nullable()
     const struct = prevStruct.brand('x', 'y')
 
-    type ExpectedKeys = 'description' | '__schema' | 'parse' | 'min' | 'max'
+    type ExpectedKeys = StructSharedKeys | 'description' | 'min' | 'max'
 
     foldB: {
       const construct = x.makeStruct(schema)
@@ -675,7 +837,7 @@ describe('Struct parameter keys reduction and schema immutability (foldB)', () =
     const prevStruct = x.number().optional().nullable().min(schema.min)
     const struct = prevStruct.brand('x', 'y')
 
-    type ExpectedKeys = 'description' | '__schema' | 'parse' | 'max'
+    type ExpectedKeys = StructSharedKeys | 'description' | 'max'
 
     foldB: {
       const construct = x.makeStruct(schema)
@@ -736,7 +898,7 @@ describe('Struct parameter keys reduction and schema immutability (foldB)', () =
 
     const struct = prevStruct.brand('x', 'y')
 
-    type ExpectedKeys = 'description' | '__schema' | 'parse'
+    type ExpectedKeys = StructSharedKeys | 'description'
 
     foldB: {
       const construct = x.makeStruct(schema)
@@ -799,7 +961,7 @@ describe('Struct parameter keys reduction and schema immutability (foldB)', () =
 
     const struct = prevStruct.brand('x', 'y')
 
-    type ExpectedKeys = '__schema' | 'parse'
+    type ExpectedKeys = StructSharedKeys
 
     foldB: {
       const construct = x.makeStruct(schema)
@@ -862,7 +1024,7 @@ describe('Struct parameter keys reduction and schema immutability (foldB)', () =
 
     const struct = prevStruct.optional()
 
-    type ExpectedKeys = '__schema' | 'parse'
+    type ExpectedKeys = StructSharedKeys
 
     foldB: {
       const construct = x.makeStruct(schema)
@@ -936,6 +1098,16 @@ describe('ERROR_CODE.invalidType (foldC)', () => {
           expect(parsedSchema.error).toStrictEqual(expectedError)
           expect(parsedConstruct.error).toStrictEqual(expectedError)
           expect(parsedStruct.error).toStrictEqual(expectedError)
+
+          const parsedStandard = struct['~standard'].validate(subject)
+
+          if (parsedStandard instanceof Promise) {
+            throw Error('Not expected')
+          }
+
+          expect(parsedStandard.issues).toStrictEqual([
+            { message: x.ERROR_CODE.invalidType, path: [] },
+          ])
         }
       }
     }
@@ -968,6 +1140,16 @@ describe('ERROR_CODE.invalidRange (foldD)', () => {
         expect(parsedSchema.error).toStrictEqual(expectedError)
         expect(parsedConstruct.error).toStrictEqual(expectedError)
         expect(parsedStruct.error).toStrictEqual(expectedError)
+
+        const parsedStandard = struct['~standard'].validate(subject)
+
+        if (parsedStandard instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        expect(parsedStandard.issues).toStrictEqual([
+          { message: x.ERROR_CODE.invalidRange, path: [] },
+        ])
       }
     }
   })
@@ -997,6 +1179,16 @@ describe('ERROR_CODE.invalidRange (foldD)', () => {
         expect(parsedSchema.error).toStrictEqual(expectedError)
         expect(parsedConstruct.error).toStrictEqual(expectedError)
         expect(parsedStruct.error).toStrictEqual(expectedError)
+
+        const parsedStandard = struct['~standard'].validate(subject)
+
+        if (parsedStandard instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        expect(parsedStandard.issues).toStrictEqual([
+          { message: x.ERROR_CODE.invalidRange, path: [] },
+        ])
       }
     }
   })
@@ -1026,6 +1218,16 @@ describe('ERROR_CODE.invalidRange (foldD)', () => {
         expect(parsedSchema.error).toStrictEqual(expectedError)
         expect(parsedConstruct.error).toStrictEqual(expectedError)
         expect(parsedStruct.error).toStrictEqual(expectedError)
+
+        const parsedStandard = struct['~standard'].validate(subject)
+
+        if (parsedStandard instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        expect(parsedStandard.issues).toStrictEqual([
+          { message: x.ERROR_CODE.invalidRange, path: [] },
+        ])
       }
     }
   })

--- a/src/tests/by-struct/object.test.ts
+++ b/src/tests/by-struct/object.test.ts
@@ -1,6 +1,8 @@
 import * as x from '../../'
 import * as fixture from '../fixtures'
 
+import type { StructSharedKeys } from '../type'
+
 describe('Type inference and parse by schema/construct/struct (foldA)', () => {
   it('required', () => {
     const schema = {
@@ -17,7 +19,7 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
     foldA: {
       const construct = x.makeStruct(schema)
 
-      /* ensure that schema/construct/struct subject types are identical */
+      /* ensure that schema/construct/struct/~standard subject types are identical */
 
       type ConstructSchemaSubj = x.Infer<typeof construct.__schema>
 
@@ -33,6 +35,13 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructSubj, ExpectedSubj>()
       x.tCh<ExpectedSubj, StructSubj>()
+
+      type StandardSubj = NonNullable<
+        (typeof struct)['~standard']['types']
+      >['output']
+
+      x.tCh<StandardSubj, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardSubj>()
 
       /* parsed either type check */
 
@@ -54,6 +63,14 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructParsed, ExpectedParsed>()
       x.tCh<ExpectedParsed, StructParsed>()
+
+      type StandardParsed = Extract<
+        ReturnType<(typeof struct)['~standard']['validate']>,
+        { value: unknown }
+      >['value']
+
+      x.tCh<StandardParsed, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardParsed>()
 
       /* runtime schema check */
 
@@ -78,6 +95,18 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
         expect(structParsed.error).toBe(undefined)
         expect(structParsed.data).toStrictEqual(subj)
+
+        const standardParsed = struct['~standard'].validate(subj)
+
+        if (standardParsed instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        if (standardParsed.issues !== undefined) {
+          throw Error('not expected')
+        }
+
+        expect(standardParsed.value).toStrictEqual(subj)
       }
     }
   })
@@ -98,7 +127,7 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
     foldA: {
       const construct = x.makeStruct(schema)
 
-      /* ensure that schema/construct/struct subject types are identical */
+      /* ensure that schema/construct/struct/~standard subject types are identical */
 
       type ConstructSchemaSubj = x.Infer<typeof construct.__schema>
 
@@ -114,6 +143,13 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructSubj, ExpectedSubj>()
       x.tCh<ExpectedSubj, StructSubj>()
+
+      type StandardSubj = NonNullable<
+        (typeof struct)['~standard']['types']
+      >['output']
+
+      x.tCh<StandardSubj, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardSubj>()
 
       /* parsed either type check */
 
@@ -135,6 +171,14 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructParsed, ExpectedParsed>()
       x.tCh<ExpectedParsed, StructParsed>()
+
+      type StandardParsed = Extract<
+        ReturnType<(typeof struct)['~standard']['validate']>,
+        { value: unknown }
+      >['value']
+
+      x.tCh<StandardParsed, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardParsed>()
 
       /* runtime schema check */
 
@@ -159,6 +203,18 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
         expect(structParsed.error).toBe(undefined)
         expect(structParsed.data).toStrictEqual(subj)
+
+        const standardParsed = struct['~standard'].validate(subj)
+
+        if (standardParsed instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        if (standardParsed.issues !== undefined) {
+          throw Error('not expected')
+        }
+
+        expect(standardParsed.value).toStrictEqual(subj)
       }
     }
   })
@@ -179,7 +235,7 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
     foldA: {
       const construct = x.makeStruct(schema)
 
-      /* ensure that schema/construct/struct subject types are identical */
+      /* ensure that schema/construct/struct/~standard subject types are identical */
 
       type ConstructSchemaSubj = x.Infer<typeof construct.__schema>
 
@@ -195,6 +251,13 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructSubj, ExpectedSubj>()
       x.tCh<ExpectedSubj, StructSubj>()
+
+      type StandardSubj = NonNullable<
+        (typeof struct)['~standard']['types']
+      >['output']
+
+      x.tCh<StandardSubj, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardSubj>()
 
       /* parsed either type check */
 
@@ -216,6 +279,14 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructParsed, ExpectedParsed>()
       x.tCh<ExpectedParsed, StructParsed>()
+
+      type StandardParsed = Extract<
+        ReturnType<(typeof struct)['~standard']['validate']>,
+        { value: unknown }
+      >['value']
+
+      x.tCh<StandardParsed, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardParsed>()
 
       /* runtime schema check */
 
@@ -240,6 +311,18 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
         expect(structParsed.error).toBe(undefined)
         expect(structParsed.data).toStrictEqual(subj)
+
+        const standardParsed = struct['~standard'].validate(subj)
+
+        if (standardParsed instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        if (standardParsed.issues !== undefined) {
+          throw Error('not expected')
+        }
+
+        expect(standardParsed.value).toStrictEqual(subj)
       }
     }
   })
@@ -261,7 +344,7 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
     foldA: {
       const construct = x.makeStruct(schema)
 
-      /* ensure that schema/construct/struct subject types are identical */
+      /* ensure that schema/construct/struct/~standard subject types are identical */
 
       type ConstructSchemaSubj = x.Infer<typeof construct.__schema>
 
@@ -277,6 +360,13 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructSubj, ExpectedSubj>()
       x.tCh<ExpectedSubj, StructSubj>()
+
+      type StandardSubj = NonNullable<
+        (typeof struct)['~standard']['types']
+      >['output']
+
+      x.tCh<StandardSubj, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardSubj>()
 
       /* parsed either type check */
 
@@ -298,6 +388,14 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructParsed, ExpectedParsed>()
       x.tCh<ExpectedParsed, StructParsed>()
+
+      type StandardParsed = Extract<
+        ReturnType<(typeof struct)['~standard']['validate']>,
+        { value: unknown }
+      >['value']
+
+      x.tCh<StandardParsed, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardParsed>()
 
       /* runtime schema check */
 
@@ -322,6 +420,18 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
         expect(structParsed.error).toBe(undefined)
         expect(structParsed.data).toStrictEqual(subj)
+
+        const standardParsed = struct['~standard'].validate(subj)
+
+        if (standardParsed instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        if (standardParsed.issues !== undefined) {
+          throw Error('not expected')
+        }
+
+        expect(standardParsed.value).toStrictEqual(subj)
       }
     }
   })
@@ -338,7 +448,7 @@ describe('Struct parameter keys reduction and schema immutability (foldB)', () =
     const prevStruct = x.object({ x: x.boolean() })
     const struct = prevStruct.optional()
 
-    type ExpectedKeys = '__schema' | 'description' | 'nullable' | 'parse'
+    type ExpectedKeys = StructSharedKeys | 'description' | 'nullable'
 
     foldB: {
       const construct = x.makeStruct(schema)
@@ -391,7 +501,7 @@ describe('Struct parameter keys reduction and schema immutability (foldB)', () =
     const prevStruct = x.object({ x: x.boolean() }).optional()
     const struct = prevStruct.nullable()
 
-    type ExpectedKeys = '__schema' | 'description' | 'parse'
+    type ExpectedKeys = StructSharedKeys | 'description'
 
     foldB: {
       const construct = x.makeStruct(schema)
@@ -446,7 +556,7 @@ describe('Struct parameter keys reduction and schema immutability (foldB)', () =
 
     const struct = prevStruct.description(schema.description)
 
-    type ExpectedKeys = '__schema' | 'parse'
+    type ExpectedKeys = StructSharedKeys
 
     foldB: {
       const construct = x.makeStruct(schema)
@@ -503,7 +613,7 @@ describe('Struct parameter keys reduction and schema immutability (foldB)', () =
 
     const struct = prevStruct.nullable().optional()
 
-    type ExpectedKeys = '__schema' | 'parse'
+    type ExpectedKeys = StructSharedKeys
 
     foldB: {
       const construct = x.makeStruct(schema)
@@ -581,6 +691,16 @@ describe('ERROR_CODE.invalidType (foldC, foldE)', () => {
           expect(parsedSchema.error).toStrictEqual(expectedError)
           expect(parsedConstruct.error).toStrictEqual(expectedError)
           expect(parsedStruct.error).toStrictEqual(expectedError)
+
+          const parsedStandard = struct['~standard'].validate(subject)
+
+          if (parsedStandard instanceof Promise) {
+            throw Error('Not expected')
+          }
+
+          expect(parsedStandard.issues).toStrictEqual([
+            { message: x.ERROR_CODE.invalidType, path: [] },
+          ])
         }
       }
     }
@@ -639,6 +759,16 @@ describe('ERROR_CODE.invalidType (foldC, foldE)', () => {
         expect(parsedSchema.error).toStrictEqual(expectedError)
         expect(parsedConstruct.error).toStrictEqual(expectedError)
         expect(parsedStruct.error).toStrictEqual(expectedError)
+
+        const parsedStandard = struct['~standard'].validate(subject)
+
+        if (parsedStandard instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        expect(parsedStandard.issues).toStrictEqual([
+          { path, message: x.ERROR_CODE.invalidType },
+        ])
       }
     }
   })
@@ -724,7 +854,7 @@ describe('Compound schema specifics (foldA)', () => {
     foldA: {
       const construct = x.makeStruct(schema)
 
-      /* ensure that schema/construct/struct subject types are identical */
+      /* ensure that schema/construct/struct/~standard subject types are identical */
 
       type ConstructSchemaSubj = x.Infer<typeof construct.__schema>
 
@@ -740,6 +870,13 @@ describe('Compound schema specifics (foldA)', () => {
 
       x.tCh<StructSubj, ExpectedSubj>()
       x.tCh<ExpectedSubj, StructSubj>()
+
+      type StandardSubj = NonNullable<
+        (typeof struct)['~standard']['types']
+      >['output']
+
+      x.tCh<StandardSubj, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardSubj>()
 
       /* parsed either type check */
 
@@ -761,6 +898,14 @@ describe('Compound schema specifics (foldA)', () => {
 
       x.tCh<StructParsed, ExpectedParsed>()
       x.tCh<ExpectedParsed, StructParsed>()
+
+      type StandardParsed = Extract<
+        ReturnType<(typeof struct)['~standard']['validate']>,
+        { value: unknown }
+      >['value']
+
+      x.tCh<StandardParsed, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardParsed>()
 
       /* runtime schema check */
 
@@ -785,6 +930,18 @@ describe('Compound schema specifics (foldA)', () => {
 
         expect(structParsed.error).toBe(undefined)
         expect(structParsed.data).toStrictEqual(subj)
+
+        const standardParsed = struct['~standard'].validate(subj)
+
+        if (standardParsed instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        if (standardParsed.issues !== undefined) {
+          throw Error('not expected')
+        }
+
+        expect(standardParsed.value).toStrictEqual(subj)
       }
     }
   })
@@ -818,7 +975,7 @@ describe('Compound schema specifics (foldA)', () => {
     foldA: {
       const construct = x.makeStruct(schema)
 
-      /* ensure that schema/construct/struct subject types are identical */
+      /* ensure that schema/construct/struct/~standard subject types are identical */
 
       type ConstructSchemaSubj = x.Infer<typeof construct.__schema>
 
@@ -834,6 +991,13 @@ describe('Compound schema specifics (foldA)', () => {
 
       x.tCh<StructSubj, ExpectedSubj>()
       x.tCh<ExpectedSubj, StructSubj>()
+
+      type StandardSubj = NonNullable<
+        (typeof struct)['~standard']['types']
+      >['output']
+
+      x.tCh<StandardSubj, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardSubj>()
 
       /* parsed either type check */
 
@@ -855,6 +1019,14 @@ describe('Compound schema specifics (foldA)', () => {
 
       x.tCh<StructParsed, ExpectedParsed>()
       x.tCh<ExpectedParsed, StructParsed>()
+
+      type StandardParsed = Extract<
+        ReturnType<(typeof struct)['~standard']['validate']>,
+        { value: unknown }
+      >['value']
+
+      x.tCh<StandardParsed, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardParsed>()
 
       /* runtime schema check */
 
@@ -879,6 +1051,18 @@ describe('Compound schema specifics (foldA)', () => {
 
         expect(structParsed.error).toBe(undefined)
         expect(structParsed.data).toStrictEqual(subj)
+
+        const standardParsed = struct['~standard'].validate(subj)
+
+        if (standardParsed instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        if (standardParsed.issues !== undefined) {
+          throw Error('not expected')
+        }
+
+        expect(standardParsed.value).toStrictEqual(subj)
       }
     }
   })
@@ -915,7 +1099,7 @@ describe('Compound schema specifics (foldA)', () => {
     foldA: {
       const construct = x.makeStruct(schema)
 
-      /* ensure that schema/construct/struct subject types are identical */
+      /* ensure that schema/construct/struct/~standard subject types are identical */
 
       type ConstructSchemaSubj = x.Infer<typeof construct.__schema>
 
@@ -931,6 +1115,13 @@ describe('Compound schema specifics (foldA)', () => {
 
       x.tCh<StructSubj, ExpectedSubj>()
       x.tCh<ExpectedSubj, StructSubj>()
+
+      type StandardSubj = NonNullable<
+        (typeof struct)['~standard']['types']
+      >['output']
+
+      x.tCh<StandardSubj, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardSubj>()
 
       /* parsed either type check */
 
@@ -952,6 +1143,14 @@ describe('Compound schema specifics (foldA)', () => {
 
       x.tCh<StructParsed, ExpectedParsed>()
       x.tCh<ExpectedParsed, StructParsed>()
+
+      type StandardParsed = Extract<
+        ReturnType<(typeof struct)['~standard']['validate']>,
+        { value: unknown }
+      >['value']
+
+      x.tCh<StandardParsed, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardParsed>()
 
       /* runtime schema check */
 
@@ -976,6 +1175,18 @@ describe('Compound schema specifics (foldA)', () => {
 
         expect(structParsed.error).toBe(undefined)
         expect(structParsed.data).toStrictEqual(subj)
+
+        const standardParsed = struct['~standard'].validate(subj)
+
+        if (standardParsed instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        if (standardParsed.issues !== undefined) {
+          throw Error('not expected')
+        }
+
+        expect(standardParsed.value).toStrictEqual(subj)
       }
     }
   })
@@ -1179,7 +1390,7 @@ describe('Compound schema specifics (foldA)', () => {
     foldA: {
       const construct = x.makeStruct(schema)
 
-      /* ensure that schema/construct/struct subject types are identical */
+      /* ensure that schema/construct/struct/~standard subject types are identical */
 
       type ConstructSchemaSubj = x.Infer<typeof construct.__schema>
 
@@ -1195,6 +1406,13 @@ describe('Compound schema specifics (foldA)', () => {
 
       x.tCh<StructSubj, ExpectedSubj>()
       x.tCh<ExpectedSubj, StructSubj>()
+
+      type StandardSubj = NonNullable<
+        (typeof struct)['~standard']['types']
+      >['output']
+
+      x.tCh<StandardSubj, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardSubj>()
 
       /* parsed either type check */
 
@@ -1216,6 +1434,14 @@ describe('Compound schema specifics (foldA)', () => {
 
       x.tCh<StructParsed, ExpectedParsed>()
       x.tCh<ExpectedParsed, StructParsed>()
+
+      type StandardParsed = Extract<
+        ReturnType<(typeof struct)['~standard']['validate']>,
+        { value: unknown }
+      >['value']
+
+      x.tCh<StandardParsed, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardParsed>()
 
       /* runtime schema check */
 
@@ -1240,6 +1466,18 @@ describe('Compound schema specifics (foldA)', () => {
 
         expect(structParsed.error).toBe(undefined)
         expect(structParsed.data).toStrictEqual(subj)
+
+        const standardParsed = struct['~standard'].validate(subj)
+
+        if (standardParsed instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        if (standardParsed.issues !== undefined) {
+          throw Error('not expected')
+        }
+
+        expect(standardParsed.value).toStrictEqual(subj)
       }
     }
   })

--- a/src/tests/by-struct/record.test.ts
+++ b/src/tests/by-struct/record.test.ts
@@ -1,6 +1,8 @@
 import * as x from '../../'
 import * as fixture from '../fixtures'
 
+import type { StructSharedKeys } from '../type'
+
 describe('Type inference and parse by schema/construct/struct (foldA)', () => {
   it('branded key', () => {
     const schema = {
@@ -27,7 +29,7 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
     foldA: {
       const construct = x.makeStruct(schema)
 
-      /* ensure that schema/construct/struct subject types are identical */
+      /* ensure that schema/construct/struct/~standard subject types are identical */
 
       type ConstructSchemaSubj = x.Infer<typeof construct.__schema>
 
@@ -43,6 +45,13 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructSubj, ExpectedSubj>()
       x.tCh<ExpectedSubj, StructSubj>()
+
+      type StandardSubj = NonNullable<
+        (typeof struct)['~standard']['types']
+      >['output']
+
+      x.tCh<StandardSubj, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardSubj>()
 
       /* parsed either type check */
 
@@ -64,6 +73,14 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructParsed, ExpectedParsed>()
       x.tCh<ExpectedParsed, StructParsed>()
+
+      type StandardParsed = Extract<
+        ReturnType<(typeof struct)['~standard']['validate']>,
+        { value: unknown }
+      >['value']
+
+      x.tCh<StandardParsed, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardParsed>()
 
       /* runtime schema check */
 
@@ -88,6 +105,18 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
         expect(structParsed.error).toBe(undefined)
         expect(structParsed.data).toStrictEqual(subj)
+
+        const standardParsed = struct['~standard'].validate(subj)
+
+        if (standardParsed instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        if (standardParsed.issues !== undefined) {
+          throw Error('not expected')
+        }
+
+        expect(standardParsed.value).toStrictEqual(subj)
       }
     }
   })
@@ -107,7 +136,7 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
     foldA: {
       const construct = x.makeStruct(schema)
 
-      /* ensure that schema/construct/struct subject types are identical */
+      /* ensure that schema/construct/struct/~standard subject types are identical */
 
       type ConstructSchemaSubj = x.Infer<typeof construct.__schema>
 
@@ -123,6 +152,13 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructSubj, ExpectedSubj>()
       x.tCh<ExpectedSubj, StructSubj>()
+
+      type StandardSubj = NonNullable<
+        (typeof struct)['~standard']['types']
+      >['output']
+
+      x.tCh<StandardSubj, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardSubj>()
 
       /* parsed either type check */
 
@@ -144,6 +180,14 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructParsed, ExpectedParsed>()
       x.tCh<ExpectedParsed, StructParsed>()
+
+      type StandardParsed = Extract<
+        ReturnType<(typeof struct)['~standard']['validate']>,
+        { value: unknown }
+      >['value']
+
+      x.tCh<StandardParsed, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardParsed>()
 
       /* runtime schema check */
 
@@ -168,6 +212,18 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
         expect(structParsed.error).toBe(undefined)
         expect(structParsed.data).toStrictEqual(subj)
+
+        const standardParsed = struct['~standard'].validate(subj)
+
+        if (standardParsed instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        if (standardParsed.issues !== undefined) {
+          throw Error('not expected')
+        }
+
+        expect(standardParsed.value).toStrictEqual(subj)
       }
     }
   })
@@ -188,7 +244,7 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
     foldA: {
       const construct = x.makeStruct(schema)
 
-      /* ensure that schema/construct/struct subject types are identical */
+      /* ensure that schema/construct/struct/~standard subject types are identical */
 
       type ConstructSchemaSubj = x.Infer<typeof construct.__schema>
 
@@ -204,6 +260,13 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructSubj, ExpectedSubj>()
       x.tCh<ExpectedSubj, StructSubj>()
+
+      type StandardSubj = NonNullable<
+        (typeof struct)['~standard']['types']
+      >['output']
+
+      x.tCh<StandardSubj, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardSubj>()
 
       /* parsed either type check */
 
@@ -225,6 +288,14 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructParsed, ExpectedParsed>()
       x.tCh<ExpectedParsed, StructParsed>()
+
+      type StandardParsed = Extract<
+        ReturnType<(typeof struct)['~standard']['validate']>,
+        { value: unknown }
+      >['value']
+
+      x.tCh<StandardParsed, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardParsed>()
 
       /* runtime schema check */
 
@@ -249,6 +320,18 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
         expect(structParsed.error).toBe(undefined)
         expect(structParsed.data).toStrictEqual(subj)
+
+        const standardParsed = struct['~standard'].validate(subj)
+
+        if (standardParsed instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        if (standardParsed.issues !== undefined) {
+          throw Error('not expected')
+        }
+
+        expect(standardParsed.value).toStrictEqual(subj)
       }
     }
   })
@@ -269,7 +352,7 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
     foldA: {
       const construct = x.makeStruct(schema)
 
-      /* ensure that schema/construct/struct subject types are identical */
+      /* ensure that schema/construct/struct/~standard subject types are identical */
 
       type ConstructSchemaSubj = x.Infer<typeof construct.__schema>
 
@@ -285,6 +368,13 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructSubj, ExpectedSubj>()
       x.tCh<ExpectedSubj, StructSubj>()
+
+      type StandardSubj = NonNullable<
+        (typeof struct)['~standard']['types']
+      >['output']
+
+      x.tCh<StandardSubj, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardSubj>()
 
       /* parsed either type check */
 
@@ -306,6 +396,14 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructParsed, ExpectedParsed>()
       x.tCh<ExpectedParsed, StructParsed>()
+
+      type StandardParsed = Extract<
+        ReturnType<(typeof struct)['~standard']['validate']>,
+        { value: unknown }
+      >['value']
+
+      x.tCh<StandardParsed, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardParsed>()
 
       /* runtime schema check */
 
@@ -330,6 +428,18 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
         expect(structParsed.error).toBe(undefined)
         expect(structParsed.data).toStrictEqual(subj)
+
+        const standardParsed = struct['~standard'].validate(subj)
+
+        if (standardParsed instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        if (standardParsed.issues !== undefined) {
+          throw Error('not expected')
+        }
+
+        expect(standardParsed.value).toStrictEqual(subj)
       }
     }
   })
@@ -355,7 +465,7 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
     foldA: {
       const construct = x.makeStruct(schema)
 
-      /* ensure that schema/construct/struct subject types are identical */
+      /* ensure that schema/construct/struct/~standard subject types are identical */
 
       type ConstructSchemaSubj = x.Infer<typeof construct.__schema>
 
@@ -371,6 +481,13 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructSubj, ExpectedSubj>()
       x.tCh<ExpectedSubj, StructSubj>()
+
+      type StandardSubj = NonNullable<
+        (typeof struct)['~standard']['types']
+      >['output']
+
+      x.tCh<StandardSubj, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardSubj>()
 
       /* parsed either type check */
 
@@ -392,6 +509,14 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructParsed, ExpectedParsed>()
       x.tCh<ExpectedParsed, StructParsed>()
+
+      type StandardParsed = Extract<
+        ReturnType<(typeof struct)['~standard']['validate']>,
+        { value: unknown }
+      >['value']
+
+      x.tCh<StandardParsed, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardParsed>()
 
       /* runtime schema check */
 
@@ -416,6 +541,18 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
         expect(structParsed.error).toBe(undefined)
         expect(structParsed.data).toStrictEqual(subj)
+
+        const standardParsed = struct['~standard'].validate(subj)
+
+        if (standardParsed instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        if (standardParsed.issues !== undefined) {
+          throw Error('not expected')
+        }
+
+        expect(standardParsed.value).toStrictEqual(subj)
       }
     }
   })
@@ -432,7 +569,7 @@ describe('Struct parameter keys reduction and schema immutability (foldB)', () =
     const prevStruct = x.record(x.boolean())
     const struct = prevStruct.optional()
 
-    type ExpectedKeys = '__schema' | 'description' | 'nullable' | 'parse'
+    type ExpectedKeys = StructSharedKeys | 'description' | 'nullable'
 
     foldB: {
       const construct = x.makeStruct(schema)
@@ -485,7 +622,7 @@ describe('Struct parameter keys reduction and schema immutability (foldB)', () =
     const prevStruct = x.record(x.boolean()).optional()
     const struct = prevStruct.nullable()
 
-    type ExpectedKeys = '__schema' | 'description' | 'parse'
+    type ExpectedKeys = StructSharedKeys | 'description'
 
     foldB: {
       const construct = x.makeStruct(schema)
@@ -539,7 +676,7 @@ describe('Struct parameter keys reduction and schema immutability (foldB)', () =
     const prevStruct = x.record(x.boolean()).optional().nullable()
     const struct = prevStruct.description('x')
 
-    type ExpectedKeys = '__schema' | 'parse'
+    type ExpectedKeys = StructSharedKeys
 
     foldB: {
       const construct = x.makeStruct(schema)
@@ -597,7 +734,7 @@ describe('Struct parameter keys reduction and schema immutability (foldB)', () =
 
     const struct = prevStruct.optional()
 
-    type ExpectedKeys = '__schema' | 'parse'
+    type ExpectedKeys = StructSharedKeys
 
     foldB: {
       const construct = x.makeStruct(schema)
@@ -675,6 +812,16 @@ describe('ERROR_CODE.invalidType (foldC, foldE)', () => {
           expect(parsedSchema.error).toStrictEqual(expectedError)
           expect(parsedConstruct.error).toStrictEqual(expectedError)
           expect(parsedStruct.error).toStrictEqual(expectedError)
+
+          const parsedStandard = struct['~standard'].validate(subject)
+
+          if (parsedStandard instanceof Promise) {
+            throw Error('Not expected')
+          }
+
+          expect(parsedStandard.issues).toStrictEqual([
+            { message: x.ERROR_CODE.invalidType, path: [] },
+          ])
         }
       }
     }
@@ -729,6 +876,16 @@ describe('ERROR_CODE.invalidType (foldC, foldE)', () => {
         expect(parsedSchema.error).toStrictEqual(expectedError)
         expect(parsedConstruct.error).toStrictEqual(expectedError)
         expect(parsedStruct.error).toStrictEqual(expectedError)
+
+        const parsedStandard = struct['~standard'].validate(subject)
+
+        if (parsedStandard instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        expect(parsedStandard.issues).toStrictEqual([
+          { path, message: x.ERROR_CODE.invalidType },
+        ])
       }
     }
   })
@@ -800,7 +957,7 @@ describe('Compound schema specifics (foldA)', () => {
     foldA: {
       const construct = x.makeStruct(schema)
 
-      /* ensure that schema/construct/struct subject types are identical */
+      /* ensure that schema/construct/struct/~standard subject types are identical */
 
       type ConstructSchemaSubj = x.Infer<typeof construct.__schema>
 
@@ -816,6 +973,13 @@ describe('Compound schema specifics (foldA)', () => {
 
       x.tCh<StructSubj, ExpectedSubj>()
       x.tCh<ExpectedSubj, StructSubj>()
+
+      type StandardSubj = NonNullable<
+        (typeof struct)['~standard']['types']
+      >['output']
+
+      x.tCh<StandardSubj, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardSubj>()
 
       /* parsed either type check */
 
@@ -837,6 +1001,14 @@ describe('Compound schema specifics (foldA)', () => {
 
       x.tCh<StructParsed, ExpectedParsed>()
       x.tCh<ExpectedParsed, StructParsed>()
+
+      type StandardParsed = Extract<
+        ReturnType<(typeof struct)['~standard']['validate']>,
+        { value: unknown }
+      >['value']
+
+      x.tCh<StandardParsed, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardParsed>()
 
       /* runtime schema check */
 
@@ -861,6 +1033,18 @@ describe('Compound schema specifics (foldA)', () => {
 
         expect(structParsed.error).toBe(undefined)
         expect(structParsed.data).toStrictEqual(subj)
+
+        const standardParsed = struct['~standard'].validate(subj)
+
+        if (standardParsed instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        if (standardParsed.issues !== undefined) {
+          throw Error('not expected')
+        }
+
+        expect(standardParsed.value).toStrictEqual(subj)
       }
     }
   })
@@ -901,7 +1085,7 @@ describe('Compound schema specifics (foldA)', () => {
     foldA: {
       const construct = x.makeStruct(schema)
 
-      /* ensure that schema/construct/struct subject types are identical */
+      /* ensure that schema/construct/struct/~standard subject types are identical */
 
       type ConstructSchemaSubj = x.Infer<typeof construct.__schema>
 
@@ -917,6 +1101,13 @@ describe('Compound schema specifics (foldA)', () => {
 
       x.tCh<StructSubj, ExpectedSubj>()
       x.tCh<ExpectedSubj, StructSubj>()
+
+      type StandardSubj = NonNullable<
+        (typeof struct)['~standard']['types']
+      >['output']
+
+      x.tCh<StandardSubj, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardSubj>()
 
       /* parsed either type check */
 
@@ -938,6 +1129,14 @@ describe('Compound schema specifics (foldA)', () => {
 
       x.tCh<StructParsed, ExpectedParsed>()
       x.tCh<ExpectedParsed, StructParsed>()
+
+      type StandardParsed = Extract<
+        ReturnType<(typeof struct)['~standard']['validate']>,
+        { value: unknown }
+      >['value']
+
+      x.tCh<StandardParsed, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardParsed>()
 
       /* runtime schema check */
 
@@ -962,6 +1161,18 @@ describe('Compound schema specifics (foldA)', () => {
 
         expect(structParsed.error).toBe(undefined)
         expect(structParsed.data).toStrictEqual(subj)
+
+        const standardParsed = struct['~standard'].validate(subj)
+
+        if (standardParsed instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        if (standardParsed.issues !== undefined) {
+          throw Error('not expected')
+        }
+
+        expect(standardParsed.value).toStrictEqual(subj)
       }
     }
   })
@@ -990,7 +1201,7 @@ describe('Compound schema specifics (foldA)', () => {
     foldA: {
       const construct = x.makeStruct(schema)
 
-      /* ensure that schema/construct/struct subject types are identical */
+      /* ensure that schema/construct/struct/~standard subject types are identical */
 
       type ConstructSchemaSubj = x.Infer<typeof construct.__schema>
 
@@ -1006,6 +1217,13 @@ describe('Compound schema specifics (foldA)', () => {
 
       x.tCh<StructSubj, ExpectedSubj>()
       x.tCh<ExpectedSubj, StructSubj>()
+
+      type StandardSubj = NonNullable<
+        (typeof struct)['~standard']['types']
+      >['output']
+
+      x.tCh<StandardSubj, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardSubj>()
 
       /* parsed either type check */
 
@@ -1027,6 +1245,14 @@ describe('Compound schema specifics (foldA)', () => {
 
       x.tCh<StructParsed, ExpectedParsed>()
       x.tCh<ExpectedParsed, StructParsed>()
+
+      type StandardParsed = Extract<
+        ReturnType<(typeof struct)['~standard']['validate']>,
+        { value: unknown }
+      >['value']
+
+      x.tCh<StandardParsed, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardParsed>()
 
       /* runtime schema check */
 
@@ -1051,6 +1277,18 @@ describe('Compound schema specifics (foldA)', () => {
 
         expect(structParsed.error).toBe(undefined)
         expect(structParsed.data).toStrictEqual(subj)
+
+        const standardParsed = struct['~standard'].validate(subj)
+
+        if (standardParsed instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        if (standardParsed.issues !== undefined) {
+          throw Error('not expected')
+        }
+
+        expect(standardParsed.value).toStrictEqual(subj)
       }
     }
   })

--- a/src/tests/by-struct/string.test.ts
+++ b/src/tests/by-struct/string.test.ts
@@ -1,6 +1,8 @@
 import * as x from '../../'
 import * as fixture from '../fixtures'
 
+import type { StructSharedKeys } from '../type'
+
 describe('Type inference and parse by schema/construct/struct (foldA)', () => {
   it('required', () => {
     const schema = { type: 'string' } as const satisfies x.Schema
@@ -13,7 +15,7 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
     foldA: {
       const construct = x.makeStruct(schema)
 
-      /* ensure that schema/construct/struct subject types are identical */
+      /* ensure that schema/construct/struct/~standard subject types are identical */
 
       type ConstructSchemaSubj = x.Infer<typeof construct.__schema>
 
@@ -29,6 +31,13 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructSubj, ExpectedSubj>()
       x.tCh<ExpectedSubj, StructSubj>()
+
+      type StandardSubj = NonNullable<
+        (typeof struct)['~standard']['types']
+      >['output']
+
+      x.tCh<StandardSubj, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardSubj>()
 
       /* parsed either type check */
 
@@ -50,6 +59,14 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructParsed, ExpectedParsed>()
       x.tCh<ExpectedParsed, StructParsed>()
+
+      type StandardParsed = Extract<
+        ReturnType<(typeof struct)['~standard']['validate']>,
+        { value: unknown }
+      >['value']
+
+      x.tCh<StandardParsed, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardParsed>()
 
       /* runtime schema check */
 
@@ -74,6 +91,18 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
         expect(structParsed.error).toBe(undefined)
         expect(structParsed.data).toStrictEqual(subj)
+
+        const standardParsed = struct['~standard'].validate(subj)
+
+        if (standardParsed instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        if (standardParsed.issues !== undefined) {
+          throw Error('not expected')
+        }
+
+        expect(standardParsed.value).toStrictEqual(subj)
       }
     }
   })
@@ -96,7 +125,7 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
     foldA: {
       const construct = x.makeStruct(schema)
 
-      /* ensure that schema/construct/struct subject types are identical */
+      /* ensure that schema/construct/struct/~standard subject types are identical */
 
       type ConstructSchemaSubj = x.Infer<typeof construct.__schema>
 
@@ -112,6 +141,13 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructSubj, ExpectedSubj>()
       x.tCh<ExpectedSubj, StructSubj>()
+
+      type StandardSubj = NonNullable<
+        (typeof struct)['~standard']['types']
+      >['output']
+
+      x.tCh<StandardSubj, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardSubj>()
 
       /* parsed either type check */
 
@@ -133,6 +169,14 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructParsed, ExpectedParsed>()
       x.tCh<ExpectedParsed, StructParsed>()
+
+      type StandardParsed = Extract<
+        ReturnType<(typeof struct)['~standard']['validate']>,
+        { value: unknown }
+      >['value']
+
+      x.tCh<StandardParsed, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardParsed>()
 
       /* runtime schema check */
 
@@ -157,6 +201,18 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
         expect(structParsed.error).toBe(undefined)
         expect(structParsed.data).toStrictEqual(subj)
+
+        const standardParsed = struct['~standard'].validate(subj)
+
+        if (standardParsed instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        if (standardParsed.issues !== undefined) {
+          throw Error('not expected')
+        }
+
+        expect(standardParsed.value).toStrictEqual(subj)
       }
     }
   })
@@ -179,7 +235,7 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
     foldA: {
       const construct = x.makeStruct(schema)
 
-      /* ensure that schema/construct/struct subject types are identical */
+      /* ensure that schema/construct/struct/~standard subject types are identical */
 
       type ConstructSchemaSubj = x.Infer<typeof construct.__schema>
 
@@ -195,6 +251,13 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructSubj, ExpectedSubj>()
       x.tCh<ExpectedSubj, StructSubj>()
+
+      type StandardSubj = NonNullable<
+        (typeof struct)['~standard']['types']
+      >['output']
+
+      x.tCh<StandardSubj, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardSubj>()
 
       /* parsed either type check */
 
@@ -216,6 +279,14 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructParsed, ExpectedParsed>()
       x.tCh<ExpectedParsed, StructParsed>()
+
+      type StandardParsed = Extract<
+        ReturnType<(typeof struct)['~standard']['validate']>,
+        { value: unknown }
+      >['value']
+
+      x.tCh<StandardParsed, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardParsed>()
 
       /* runtime schema check */
 
@@ -240,6 +311,18 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
         expect(structParsed.error).toBe(undefined)
         expect(structParsed.data).toStrictEqual(subj)
+
+        const standardParsed = struct['~standard'].validate(subj)
+
+        if (standardParsed instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        if (standardParsed.issues !== undefined) {
+          throw Error('not expected')
+        }
+
+        expect(standardParsed.value).toStrictEqual(subj)
       }
     }
   })
@@ -259,7 +342,7 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
     foldA: {
       const construct = x.makeStruct(schema)
 
-      /* ensure that schema/construct/struct subject types are identical */
+      /* ensure that schema/construct/struct/~standard subject types are identical */
 
       type ConstructSchemaSubj = x.Infer<typeof construct.__schema>
 
@@ -275,6 +358,13 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructSubj, ExpectedSubj>()
       x.tCh<ExpectedSubj, StructSubj>()
+
+      type StandardSubj = NonNullable<
+        (typeof struct)['~standard']['types']
+      >['output']
+
+      x.tCh<StandardSubj, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardSubj>()
 
       /* parsed either type check */
 
@@ -296,6 +386,14 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructParsed, ExpectedParsed>()
       x.tCh<ExpectedParsed, StructParsed>()
+
+      type StandardParsed = Extract<
+        ReturnType<(typeof struct)['~standard']['validate']>,
+        { value: unknown }
+      >['value']
+
+      x.tCh<StandardParsed, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardParsed>()
 
       /* runtime schema check */
 
@@ -320,6 +418,18 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
         expect(structParsed.error).toBe(undefined)
         expect(structParsed.data).toStrictEqual(subj)
+
+        const standardParsed = struct['~standard'].validate(subj)
+
+        if (standardParsed instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        if (standardParsed.issues !== undefined) {
+          throw Error('not expected')
+        }
+
+        expect(standardParsed.value).toStrictEqual(subj)
       }
     }
   })
@@ -339,7 +449,7 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
     foldA: {
       const construct = x.makeStruct(schema)
 
-      /* ensure that schema/construct/struct subject types are identical */
+      /* ensure that schema/construct/struct/~standard subject types are identical */
 
       type ConstructSchemaSubj = x.Infer<typeof construct.__schema>
 
@@ -355,6 +465,13 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructSubj, ExpectedSubj>()
       x.tCh<ExpectedSubj, StructSubj>()
+
+      type StandardSubj = NonNullable<
+        (typeof struct)['~standard']['types']
+      >['output']
+
+      x.tCh<StandardSubj, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardSubj>()
 
       /* parsed either type check */
 
@@ -376,6 +493,14 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructParsed, ExpectedParsed>()
       x.tCh<ExpectedParsed, StructParsed>()
+
+      type StandardParsed = Extract<
+        ReturnType<(typeof struct)['~standard']['validate']>,
+        { value: unknown }
+      >['value']
+
+      x.tCh<StandardParsed, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardParsed>()
 
       /* runtime schema check */
 
@@ -400,6 +525,18 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
         expect(structParsed.error).toBe(undefined)
         expect(structParsed.data).toStrictEqual(subj)
+
+        const standardParsed = struct['~standard'].validate(subj)
+
+        if (standardParsed instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        if (standardParsed.issues !== undefined) {
+          throw Error('not expected')
+        }
+
+        expect(standardParsed.value).toStrictEqual(subj)
       }
     }
   })
@@ -427,7 +564,7 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
     foldA: {
       const construct = x.makeStruct(schema)
 
-      /* ensure that schema/construct/struct subject types are identical */
+      /* ensure that schema/construct/struct/~standard subject types are identical */
 
       type ConstructSchemaSubj = x.Infer<typeof construct.__schema>
 
@@ -443,6 +580,13 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructSubj, ExpectedSubj>()
       x.tCh<ExpectedSubj, StructSubj>()
+
+      type StandardSubj = NonNullable<
+        (typeof struct)['~standard']['types']
+      >['output']
+
+      x.tCh<StandardSubj, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardSubj>()
 
       /* parsed either type check */
 
@@ -464,6 +608,14 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructParsed, ExpectedParsed>()
       x.tCh<ExpectedParsed, StructParsed>()
+
+      type StandardParsed = Extract<
+        ReturnType<(typeof struct)['~standard']['validate']>,
+        { value: unknown }
+      >['value']
+
+      x.tCh<StandardParsed, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardParsed>()
 
       /* runtime schema check */
 
@@ -488,6 +640,18 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
         expect(structParsed.error).toBe(undefined)
         expect(structParsed.data).toStrictEqual(subj)
+
+        const standardParsed = struct['~standard'].validate(subj)
+
+        if (standardParsed instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        if (standardParsed.issues !== undefined) {
+          throw Error('not expected')
+        }
+
+        expect(standardParsed.value).toStrictEqual(subj)
       }
     }
   })
@@ -504,13 +668,12 @@ describe('Struct parameter keys reduction and schema immutability (foldB)', () =
     const struct = prevStruct.optional()
 
     type ExpectedKeys =
-      | '__schema'
+      | StructSharedKeys
       | 'brand'
       | 'description'
       | 'maxLength'
       | 'minLength'
       | 'nullable'
-      | 'parse'
 
     foldB: {
       const construct = x.makeStruct(schema)
@@ -563,12 +726,11 @@ describe('Struct parameter keys reduction and schema immutability (foldB)', () =
     const struct = prevStruct.nullable()
 
     type ExpectedKeys =
-      | '__schema'
+      | StructSharedKeys
       | 'brand'
       | 'description'
       | 'maxLength'
       | 'minLength'
-      | 'parse'
 
     foldB: {
       const construct = x.makeStruct(schema)
@@ -622,9 +784,8 @@ describe('Struct parameter keys reduction and schema immutability (foldB)', () =
     const struct = prevStruct.brand('x', 'y')
 
     type ExpectedKeys =
+      | StructSharedKeys
       | 'description'
-      | '__schema'
-      | 'parse'
       | 'minLength'
       | 'maxLength'
 
@@ -685,7 +846,7 @@ describe('Struct parameter keys reduction and schema immutability (foldB)', () =
 
     const struct = prevStruct.brand('x', 'y')
 
-    type ExpectedKeys = 'description' | '__schema' | 'parse' | 'maxLength'
+    type ExpectedKeys = StructSharedKeys | 'description' | 'maxLength'
 
     foldB: {
       const construct = x.makeStruct(schema)
@@ -746,7 +907,7 @@ describe('Struct parameter keys reduction and schema immutability (foldB)', () =
 
     const struct = prevStruct.brand('x', 'y')
 
-    type ExpectedKeys = 'description' | '__schema' | 'parse'
+    type ExpectedKeys = StructSharedKeys | 'description'
 
     foldB: {
       const construct = x.makeStruct(schema)
@@ -809,7 +970,7 @@ describe('Struct parameter keys reduction and schema immutability (foldB)', () =
 
     const struct = prevStruct.brand('x', 'y')
 
-    type ExpectedKeys = '__schema' | 'parse'
+    type ExpectedKeys = StructSharedKeys
 
     foldB: {
       const construct = x.makeStruct(schema)
@@ -872,7 +1033,7 @@ describe('Struct parameter keys reduction and schema immutability (foldB)', () =
 
     const struct = prevStruct.optional()
 
-    type ExpectedKeys = '__schema' | 'parse'
+    type ExpectedKeys = StructSharedKeys
 
     foldB: {
       const construct = x.makeStruct(schema)
@@ -946,6 +1107,16 @@ describe('ERROR_CODE.invalidType (foldC)', () => {
           expect(parsedSchema.error).toStrictEqual(expectedError)
           expect(parsedConstruct.error).toStrictEqual(expectedError)
           expect(parsedStruct.error).toStrictEqual(expectedError)
+
+          const parsedStandard = struct['~standard'].validate(subject)
+
+          if (parsedStandard instanceof Promise) {
+            throw Error('Not expected')
+          }
+
+          expect(parsedStandard.issues).toStrictEqual([
+            { message: x.ERROR_CODE.invalidType, path: [] },
+          ])
         }
       }
     }
@@ -978,6 +1149,16 @@ describe('ERROR_CODE.invalidRange (foldD)', () => {
         expect(parsedSchema.error).toStrictEqual(expectedError)
         expect(parsedConstruct.error).toStrictEqual(expectedError)
         expect(parsedStruct.error).toStrictEqual(expectedError)
+
+        const parsedStandard = struct['~standard'].validate(subject)
+
+        if (parsedStandard instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        expect(parsedStandard.issues).toStrictEqual([
+          { message: x.ERROR_CODE.invalidRange, path: [] },
+        ])
       }
     }
   })
@@ -1007,6 +1188,16 @@ describe('ERROR_CODE.invalidRange (foldD)', () => {
         expect(parsedSchema.error).toStrictEqual(expectedError)
         expect(parsedConstruct.error).toStrictEqual(expectedError)
         expect(parsedStruct.error).toStrictEqual(expectedError)
+
+        const parsedStandard = struct['~standard'].validate(subject)
+
+        if (parsedStandard instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        expect(parsedStandard.issues).toStrictEqual([
+          { message: x.ERROR_CODE.invalidRange, path: [] },
+        ])
       }
     }
   })
@@ -1045,6 +1236,16 @@ describe('ERROR_CODE.invalidRange (foldD)', () => {
         expect(parsedSchema.error).toStrictEqual(expectedError)
         expect(parsedConstruct.error).toStrictEqual(expectedError)
         expect(parsedStruct.error).toStrictEqual(expectedError)
+
+        const parsedStandard = struct['~standard'].validate(subject)
+
+        if (parsedStandard instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        expect(parsedStandard.issues).toStrictEqual([
+          { message: x.ERROR_CODE.invalidRange, path: [] },
+        ])
       }
     }
   })

--- a/src/tests/by-struct/tuple.test.ts
+++ b/src/tests/by-struct/tuple.test.ts
@@ -1,6 +1,8 @@
 import * as x from '../../'
 import * as fixture from '../fixtures'
 
+import type { StructSharedKeys } from '../type'
+
 describe('Type inference and parse by schema/construct/struct (foldA)', () => {
   it('required', () => {
     const schema = {
@@ -20,7 +22,7 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
     foldA: {
       const construct = x.makeStruct(schema)
 
-      /* ensure that schema/construct/struct subject types are identical */
+      /* ensure that schema/construct/struct/~standard subject types are identical */
 
       type ConstructSchemaSubj = x.Infer<typeof construct.__schema>
 
@@ -36,6 +38,13 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructSubj, ExpectedSubj>()
       x.tCh<ExpectedSubj, StructSubj>()
+
+      type StandardSubj = NonNullable<
+        (typeof struct)['~standard']['types']
+      >['output']
+
+      x.tCh<StandardSubj, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardSubj>()
 
       /* parsed either type check */
 
@@ -57,6 +66,14 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructParsed, ExpectedParsed>()
       x.tCh<ExpectedParsed, StructParsed>()
+
+      type StandardParsed = Extract<
+        ReturnType<(typeof struct)['~standard']['validate']>,
+        { value: unknown }
+      >['value']
+
+      x.tCh<StandardParsed, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardParsed>()
 
       /* runtime schema check */
 
@@ -81,6 +98,18 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
         expect(structParsed.error).toBe(undefined)
         expect(structParsed.data).toStrictEqual(subj)
+
+        const standardParsed = struct['~standard'].validate(subj)
+
+        if (standardParsed instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        if (standardParsed.issues !== undefined) {
+          throw Error('not expected')
+        }
+
+        expect(standardParsed.value).toStrictEqual(subj)
       }
     }
   })
@@ -101,7 +130,7 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
     foldA: {
       const construct = x.makeStruct(schema)
 
-      /* ensure that schema/construct/struct subject types are identical */
+      /* ensure that schema/construct/struct/~standard subject types are identical */
 
       type ConstructSchemaSubj = x.Infer<typeof construct.__schema>
 
@@ -117,6 +146,13 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructSubj, ExpectedSubj>()
       x.tCh<ExpectedSubj, StructSubj>()
+
+      type StandardSubj = NonNullable<
+        (typeof struct)['~standard']['types']
+      >['output']
+
+      x.tCh<StandardSubj, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardSubj>()
 
       /* parsed either type check */
 
@@ -138,6 +174,14 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructParsed, ExpectedParsed>()
       x.tCh<ExpectedParsed, StructParsed>()
+
+      type StandardParsed = Extract<
+        ReturnType<(typeof struct)['~standard']['validate']>,
+        { value: unknown }
+      >['value']
+
+      x.tCh<StandardParsed, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardParsed>()
 
       /* runtime schema check */
 
@@ -162,6 +206,18 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
         expect(structParsed.error).toBe(undefined)
         expect(structParsed.data).toStrictEqual(subj)
+
+        const standardParsed = struct['~standard'].validate(subj)
+
+        if (standardParsed instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        if (standardParsed.issues !== undefined) {
+          throw Error('not expected')
+        }
+
+        expect(standardParsed.value).toStrictEqual(subj)
       }
     }
   })
@@ -182,7 +238,7 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
     foldA: {
       const construct = x.makeStruct(schema)
 
-      /* ensure that schema/construct/struct subject types are identical */
+      /* ensure that schema/construct/struct/~standard subject types are identical */
 
       type ConstructSchemaSubj = x.Infer<typeof construct.__schema>
 
@@ -198,6 +254,13 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructSubj, ExpectedSubj>()
       x.tCh<ExpectedSubj, StructSubj>()
+
+      type StandardSubj = NonNullable<
+        (typeof struct)['~standard']['types']
+      >['output']
+
+      x.tCh<StandardSubj, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardSubj>()
 
       /* parsed either type check */
 
@@ -219,6 +282,14 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructParsed, ExpectedParsed>()
       x.tCh<ExpectedParsed, StructParsed>()
+
+      type StandardParsed = Extract<
+        ReturnType<(typeof struct)['~standard']['validate']>,
+        { value: unknown }
+      >['value']
+
+      x.tCh<StandardParsed, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardParsed>()
 
       /* runtime schema check */
 
@@ -243,6 +314,18 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
         expect(structParsed.error).toBe(undefined)
         expect(structParsed.data).toStrictEqual(subj)
+
+        const standardParsed = struct['~standard'].validate(subj)
+
+        if (standardParsed instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        if (standardParsed.issues !== undefined) {
+          throw Error('not expected')
+        }
+
+        expect(standardParsed.value).toStrictEqual(subj)
       }
     }
   })
@@ -272,7 +355,7 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
     foldA: {
       const construct = x.makeStruct(schema)
 
-      /* ensure that schema/construct/struct subject types are identical */
+      /* ensure that schema/construct/struct/~standard subject types are identical */
 
       type ConstructSchemaSubj = x.Infer<typeof construct.__schema>
 
@@ -288,6 +371,13 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructSubj, ExpectedSubj>()
       x.tCh<ExpectedSubj, StructSubj>()
+
+      type StandardSubj = NonNullable<
+        (typeof struct)['~standard']['types']
+      >['output']
+
+      x.tCh<StandardSubj, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardSubj>()
 
       /* parsed either type check */
 
@@ -309,6 +399,14 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructParsed, ExpectedParsed>()
       x.tCh<ExpectedParsed, StructParsed>()
+
+      type StandardParsed = Extract<
+        ReturnType<(typeof struct)['~standard']['validate']>,
+        { value: unknown }
+      >['value']
+
+      x.tCh<StandardParsed, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardParsed>()
 
       /* runtime schema check */
 
@@ -333,6 +431,18 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
         expect(structParsed.error).toBe(undefined)
         expect(structParsed.data).toStrictEqual(subj)
+
+        const standardParsed = struct['~standard'].validate(subj)
+
+        if (standardParsed instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        if (standardParsed.issues !== undefined) {
+          throw Error('not expected')
+        }
+
+        expect(standardParsed.value).toStrictEqual(subj)
       }
     }
   })
@@ -349,7 +459,7 @@ describe('Struct parameter keys reduction and schema immutability (foldB)', () =
     const prevStruct = x.tuple([x.boolean()])
     const struct = prevStruct.optional()
 
-    type ExpectedKeys = '__schema' | 'description' | 'nullable' | 'parse'
+    type ExpectedKeys = StructSharedKeys | 'description' | 'nullable'
 
     foldB: {
       const construct = x.makeStruct(schema)
@@ -402,7 +512,7 @@ describe('Struct parameter keys reduction and schema immutability (foldB)', () =
     const prevStruct = x.tuple([x.boolean()]).optional()
     const struct = prevStruct.nullable()
 
-    type ExpectedKeys = '__schema' | 'description' | 'parse'
+    type ExpectedKeys = StructSharedKeys | 'description'
 
     foldB: {
       const construct = x.makeStruct(schema)
@@ -456,7 +566,7 @@ describe('Struct parameter keys reduction and schema immutability (foldB)', () =
     const prevStruct = x.tuple([x.boolean()]).optional().nullable()
     const struct = prevStruct.description(schema.description)
 
-    type ExpectedKeys = '__schema' | 'parse'
+    type ExpectedKeys = StructSharedKeys
 
     foldB: {
       const construct = x.makeStruct(schema)
@@ -514,7 +624,7 @@ describe('Struct parameter keys reduction and schema immutability (foldB)', () =
 
     const struct = prevStruct.optional()
 
-    type ExpectedKeys = '__schema' | 'parse'
+    type ExpectedKeys = StructSharedKeys
 
     foldB: {
       const construct = x.makeStruct(schema)
@@ -592,6 +702,16 @@ describe('ERROR_CODE.invalidType (foldC, foldE)', () => {
           expect(parsedSchema.error).toStrictEqual(expectedError)
           expect(parsedConstruct.error).toStrictEqual(expectedError)
           expect(parsedStruct.error).toStrictEqual(expectedError)
+
+          const parsedStandard = struct['~standard'].validate(subject)
+
+          if (parsedStandard instanceof Promise) {
+            throw Error('Not expected')
+          }
+
+          expect(parsedStandard.issues).toStrictEqual([
+            { message: x.ERROR_CODE.invalidType, path: [] },
+          ])
         }
       }
     }
@@ -651,6 +771,16 @@ describe('ERROR_CODE.invalidType (foldC, foldE)', () => {
         expect(parsedSchema.error).toStrictEqual(expectedError)
         expect(parsedConstruct.error).toStrictEqual(expectedError)
         expect(parsedStruct.error).toStrictEqual(expectedError)
+
+        const parsedStandard = struct['~standard'].validate(subject)
+
+        if (parsedStandard instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        expect(parsedStandard.issues).toStrictEqual([
+          { path, message: x.ERROR_CODE.invalidType },
+        ])
       }
     }
   })
@@ -727,7 +857,7 @@ describe('Compound schema specifics (foldA)', () => {
     foldA: {
       const construct = x.makeStruct(schema)
 
-      /* ensure that schema/construct/struct subject types are identical */
+      /* ensure that schema/construct/struct/~standard subject types are identical */
 
       type ConstructSchemaSubj = x.Infer<typeof construct.__schema>
 
@@ -743,6 +873,13 @@ describe('Compound schema specifics (foldA)', () => {
 
       x.tCh<StructSubj, ExpectedSubj>()
       x.tCh<ExpectedSubj, StructSubj>()
+
+      type StandardSubj = NonNullable<
+        (typeof struct)['~standard']['types']
+      >['output']
+
+      x.tCh<StandardSubj, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardSubj>()
 
       /* parsed either type check */
 
@@ -764,6 +901,14 @@ describe('Compound schema specifics (foldA)', () => {
 
       x.tCh<StructParsed, ExpectedParsed>()
       x.tCh<ExpectedParsed, StructParsed>()
+
+      type StandardParsed = Extract<
+        ReturnType<(typeof struct)['~standard']['validate']>,
+        { value: unknown }
+      >['value']
+
+      x.tCh<StandardParsed, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardParsed>()
 
       /* runtime schema check */
 
@@ -788,6 +933,18 @@ describe('Compound schema specifics (foldA)', () => {
 
         expect(structParsed.error).toBe(undefined)
         expect(structParsed.data).toStrictEqual(subj)
+
+        const standardParsed = struct['~standard'].validate(subj)
+
+        if (standardParsed instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        if (standardParsed.issues !== undefined) {
+          throw Error('not expected')
+        }
+
+        expect(standardParsed.value).toStrictEqual(subj)
       }
     }
   })
@@ -818,7 +975,7 @@ describe('Compound schema specifics (foldA)', () => {
     foldA: {
       const construct = x.makeStruct(schema)
 
-      /* ensure that schema/construct/struct subject types are identical */
+      /* ensure that schema/construct/struct/~standard subject types are identical */
 
       type ConstructSchemaSubj = x.Infer<typeof construct.__schema>
 
@@ -834,6 +991,13 @@ describe('Compound schema specifics (foldA)', () => {
 
       x.tCh<StructSubj, ExpectedSubj>()
       x.tCh<ExpectedSubj, StructSubj>()
+
+      type StandardSubj = NonNullable<
+        (typeof struct)['~standard']['types']
+      >['output']
+
+      x.tCh<StandardSubj, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardSubj>()
 
       /* parsed either type check */
 
@@ -855,6 +1019,14 @@ describe('Compound schema specifics (foldA)', () => {
 
       x.tCh<StructParsed, ExpectedParsed>()
       x.tCh<ExpectedParsed, StructParsed>()
+
+      type StandardParsed = Extract<
+        ReturnType<(typeof struct)['~standard']['validate']>,
+        { value: unknown }
+      >['value']
+
+      x.tCh<StandardParsed, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardParsed>()
 
       /* runtime schema check */
 
@@ -879,6 +1051,18 @@ describe('Compound schema specifics (foldA)', () => {
 
         expect(structParsed.error).toBe(undefined)
         expect(structParsed.data).toStrictEqual(subj)
+
+        const standardParsed = struct['~standard'].validate(subj)
+
+        if (standardParsed instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        if (standardParsed.issues !== undefined) {
+          throw Error('not expected')
+        }
+
+        expect(standardParsed.value).toStrictEqual(subj)
       }
     }
   })
@@ -911,7 +1095,7 @@ describe('Compound schema specifics (foldA)', () => {
     foldA: {
       const construct = x.makeStruct(schema)
 
-      /* ensure that schema/construct/struct subject types are identical */
+      /* ensure that schema/construct/struct/~standard subject types are identical */
 
       type ConstructSchemaSubj = x.Infer<typeof construct.__schema>
 
@@ -927,6 +1111,13 @@ describe('Compound schema specifics (foldA)', () => {
 
       x.tCh<StructSubj, ExpectedSubj>()
       x.tCh<ExpectedSubj, StructSubj>()
+
+      type StandardSubj = NonNullable<
+        (typeof struct)['~standard']['types']
+      >['output']
+
+      x.tCh<StandardSubj, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardSubj>()
 
       /* parsed either type check */
 
@@ -948,6 +1139,14 @@ describe('Compound schema specifics (foldA)', () => {
 
       x.tCh<StructParsed, ExpectedParsed>()
       x.tCh<ExpectedParsed, StructParsed>()
+
+      type StandardParsed = Extract<
+        ReturnType<(typeof struct)['~standard']['validate']>,
+        { value: unknown }
+      >['value']
+
+      x.tCh<StandardParsed, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardParsed>()
 
       /* runtime schema check */
 
@@ -972,6 +1171,18 @@ describe('Compound schema specifics (foldA)', () => {
 
         expect(structParsed.error).toBe(undefined)
         expect(structParsed.data).toStrictEqual(subj)
+
+        const standardParsed = struct['~standard'].validate(subj)
+
+        if (standardParsed instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        if (standardParsed.issues !== undefined) {
+          throw Error('not expected')
+        }
+
+        expect(standardParsed.value).toStrictEqual(subj)
       }
     }
   })
@@ -1036,7 +1247,7 @@ describe('Compound schema specifics (foldA)', () => {
     foldA: {
       const construct = x.makeStruct(schema)
 
-      /* ensure that schema/construct/struct subject types are identical */
+      /* ensure that schema/construct/struct/~standard subject types are identical */
 
       type ConstructSchemaSubj = x.Infer<typeof construct.__schema>
 
@@ -1052,6 +1263,13 @@ describe('Compound schema specifics (foldA)', () => {
 
       x.tCh<StructSubj, ExpectedSubj>()
       x.tCh<ExpectedSubj, StructSubj>()
+
+      type StandardSubj = NonNullable<
+        (typeof struct)['~standard']['types']
+      >['output']
+
+      x.tCh<StandardSubj, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardSubj>()
 
       /* parsed either type check */
 
@@ -1073,6 +1291,14 @@ describe('Compound schema specifics (foldA)', () => {
 
       x.tCh<StructParsed, ExpectedParsed>()
       x.tCh<ExpectedParsed, StructParsed>()
+
+      type StandardParsed = Extract<
+        ReturnType<(typeof struct)['~standard']['validate']>,
+        { value: unknown }
+      >['value']
+
+      x.tCh<StandardParsed, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardParsed>()
 
       /* runtime schema check */
 
@@ -1097,6 +1323,18 @@ describe('Compound schema specifics (foldA)', () => {
 
         expect(structParsed.error).toBe(undefined)
         expect(structParsed.data).toStrictEqual(subj)
+
+        const standardParsed = struct['~standard'].validate(subj)
+
+        if (standardParsed instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        if (standardParsed.issues !== undefined) {
+          throw Error('not expected')
+        }
+
+        expect(standardParsed.value).toStrictEqual(subj)
       }
     }
   })

--- a/src/tests/by-struct/union.test.ts
+++ b/src/tests/by-struct/union.test.ts
@@ -1,6 +1,8 @@
 import * as x from '../../'
 import * as fixture from '../fixtures'
 
+import type { StructSharedKeys } from '../type'
+
 describe('Type inference and parse by schema/construct/struct (foldA)', () => {
   it('required', () => {
     const schema = {
@@ -17,7 +19,7 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
     foldA: {
       const construct = x.makeStruct(schema)
 
-      /* ensure that schema/construct/struct subject types are identical */
+      /* ensure that schema/construct/struct/~standard subject types are identical */
 
       type ConstructSchemaSubj = x.Infer<typeof construct.__schema>
 
@@ -33,6 +35,13 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructSubj, ExpectedSubj>()
       x.tCh<ExpectedSubj, StructSubj>()
+
+      type StandardSubj = NonNullable<
+        (typeof struct)['~standard']['types']
+      >['output']
+
+      x.tCh<StandardSubj, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardSubj>()
 
       /* parsed either type check */
 
@@ -54,6 +63,14 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructParsed, ExpectedParsed>()
       x.tCh<ExpectedParsed, StructParsed>()
+
+      type StandardParsed = Extract<
+        ReturnType<(typeof struct)['~standard']['validate']>,
+        { value: unknown }
+      >['value']
+
+      x.tCh<StandardParsed, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardParsed>()
 
       /* runtime schema check */
 
@@ -78,6 +95,18 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
         expect(structParsed.error).toBe(undefined)
         expect(structParsed.data).toStrictEqual(subj)
+
+        const standardParsed = struct['~standard'].validate(subj)
+
+        if (standardParsed instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        if (standardParsed.issues !== undefined) {
+          throw Error('not expected')
+        }
+
+        expect(standardParsed.value).toStrictEqual(subj)
       }
     }
   })
@@ -98,7 +127,7 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
     foldA: {
       const construct = x.makeStruct(schema)
 
-      /* ensure that schema/construct/struct subject types are identical */
+      /* ensure that schema/construct/struct/~standard subject types are identical */
 
       type ConstructSchemaSubj = x.Infer<typeof construct.__schema>
 
@@ -114,6 +143,13 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructSubj, ExpectedSubj>()
       x.tCh<ExpectedSubj, StructSubj>()
+
+      type StandardSubj = NonNullable<
+        (typeof struct)['~standard']['types']
+      >['output']
+
+      x.tCh<StandardSubj, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardSubj>()
 
       /* parsed either type check */
 
@@ -135,6 +171,14 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructParsed, ExpectedParsed>()
       x.tCh<ExpectedParsed, StructParsed>()
+
+      type StandardParsed = Extract<
+        ReturnType<(typeof struct)['~standard']['validate']>,
+        { value: unknown }
+      >['value']
+
+      x.tCh<StandardParsed, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardParsed>()
 
       /* runtime schema check */
 
@@ -159,6 +203,18 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
         expect(structParsed.error).toBe(undefined)
         expect(structParsed.data).toStrictEqual(subj)
+
+        const standardParsed = struct['~standard'].validate(subj)
+
+        if (standardParsed instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        if (standardParsed.issues !== undefined) {
+          throw Error('not expected')
+        }
+
+        expect(standardParsed.value).toStrictEqual(subj)
       }
     }
   })
@@ -179,7 +235,7 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
     foldA: {
       const construct = x.makeStruct(schema)
 
-      /* ensure that schema/construct/struct subject types are identical */
+      /* ensure that schema/construct/struct/~standard subject types are identical */
 
       type ConstructSchemaSubj = x.Infer<typeof construct.__schema>
 
@@ -195,6 +251,13 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructSubj, ExpectedSubj>()
       x.tCh<ExpectedSubj, StructSubj>()
+
+      type StandardSubj = NonNullable<
+        (typeof struct)['~standard']['types']
+      >['output']
+
+      x.tCh<StandardSubj, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardSubj>()
 
       /* parsed either type check */
 
@@ -216,6 +279,14 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructParsed, ExpectedParsed>()
       x.tCh<ExpectedParsed, StructParsed>()
+
+      type StandardParsed = Extract<
+        ReturnType<(typeof struct)['~standard']['validate']>,
+        { value: unknown }
+      >['value']
+
+      x.tCh<StandardParsed, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardParsed>()
 
       /* runtime schema check */
 
@@ -240,6 +311,18 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
         expect(structParsed.error).toBe(undefined)
         expect(structParsed.data).toStrictEqual(subj)
+
+        const standardParsed = struct['~standard'].validate(subj)
+
+        if (standardParsed instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        if (standardParsed.issues !== undefined) {
+          throw Error('not expected')
+        }
+
+        expect(standardParsed.value).toStrictEqual(subj)
       }
     }
   })
@@ -264,7 +347,7 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
     foldA: {
       const construct = x.makeStruct(schema)
 
-      /* ensure that schema/construct/struct subject types are identical */
+      /* ensure that schema/construct/struct/~standard subject types are identical */
 
       type ConstructSchemaSubj = x.Infer<typeof construct.__schema>
 
@@ -280,6 +363,13 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructSubj, ExpectedSubj>()
       x.tCh<ExpectedSubj, StructSubj>()
+
+      type StandardSubj = NonNullable<
+        (typeof struct)['~standard']['types']
+      >['output']
+
+      x.tCh<StandardSubj, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardSubj>()
 
       /* parsed either type check */
 
@@ -301,6 +391,14 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
       x.tCh<StructParsed, ExpectedParsed>()
       x.tCh<ExpectedParsed, StructParsed>()
+
+      type StandardParsed = Extract<
+        ReturnType<(typeof struct)['~standard']['validate']>,
+        { value: unknown }
+      >['value']
+
+      x.tCh<StandardParsed, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardParsed>()
 
       /* runtime schema check */
 
@@ -325,6 +423,18 @@ describe('Type inference and parse by schema/construct/struct (foldA)', () => {
 
         expect(structParsed.error).toBe(undefined)
         expect(structParsed.data).toStrictEqual(subj)
+
+        const standardParsed = struct['~standard'].validate(subj)
+
+        if (standardParsed instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        if (standardParsed.issues !== undefined) {
+          throw Error('not expected')
+        }
+
+        expect(standardParsed.value).toStrictEqual(subj)
       }
     }
   })
@@ -341,7 +451,7 @@ describe('Struct parameter keys reduction and schema immutability (foldB)', () =
     const prevStruct = x.union([x.boolean()])
     const struct = prevStruct.optional()
 
-    type ExpectedKeys = '__schema' | 'description' | 'nullable' | 'parse'
+    type ExpectedKeys = StructSharedKeys | 'description' | 'nullable'
 
     foldB: {
       const construct = x.makeStruct(schema)
@@ -394,7 +504,7 @@ describe('Struct parameter keys reduction and schema immutability (foldB)', () =
     const prevStruct = x.union([x.boolean()]).optional()
     const struct = prevStruct.nullable()
 
-    type ExpectedKeys = '__schema' | 'description' | 'parse'
+    type ExpectedKeys = StructSharedKeys | 'description'
 
     foldB: {
       const construct = x.makeStruct(schema)
@@ -448,7 +558,7 @@ describe('Struct parameter keys reduction and schema immutability (foldB)', () =
     const prevStruct = x.union([x.boolean()]).optional().nullable()
     const struct = prevStruct.description(schema.description)
 
-    type ExpectedKeys = '__schema' | 'parse'
+    type ExpectedKeys = StructSharedKeys
 
     foldB: {
       const construct = x.makeStruct(schema)
@@ -506,7 +616,7 @@ describe('Struct parameter keys reduction and schema immutability (foldB)', () =
 
     const struct = prevStruct.optional()
 
-    type ExpectedKeys = '__schema' | 'parse'
+    type ExpectedKeys = StructSharedKeys
 
     foldB: {
       const construct = x.makeStruct(schema)
@@ -586,6 +696,16 @@ describe('ERROR_CODE.invalidType (foldC, foldE)', () => {
           expect(parsedSchema.error).toStrictEqual(expectedError)
           expect(parsedConstruct.error).toStrictEqual(expectedError)
           expect(parsedStruct.error).toStrictEqual(expectedError)
+
+          const parsedStandard = struct['~standard'].validate(subject)
+
+          if (parsedStandard instanceof Promise) {
+            throw Error('Not expected')
+          }
+
+          expect(parsedStandard.issues).toStrictEqual([
+            { message: x.ERROR_CODE.invalidType, path: [] },
+          ])
         }
       }
     }
@@ -640,6 +760,16 @@ describe('ERROR_CODE.invalidType (foldC, foldE)', () => {
         expect(parsedSchema.error).toStrictEqual(expectedError)
         expect(parsedConstruct.error).toStrictEqual(expectedError)
         expect(parsedStruct.error).toStrictEqual(expectedError)
+
+        const parsedStandard = struct['~standard'].validate(subject)
+
+        if (parsedStandard instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        expect(parsedStandard.issues).toStrictEqual([
+          { path, message: x.ERROR_CODE.invalidType },
+        ])
       }
     }
   })
@@ -680,7 +810,7 @@ describe('Compound schema specifics (foldA)', () => {
     foldA: {
       const construct = x.makeStruct(schema)
 
-      /* ensure that schema/construct/struct subject types are identical */
+      /* ensure that schema/construct/struct/~standard subject types are identical */
 
       type ConstructSchemaSubj = x.Infer<typeof construct.__schema>
 
@@ -696,6 +826,13 @@ describe('Compound schema specifics (foldA)', () => {
 
       x.tCh<StructSubj, ExpectedSubj>()
       x.tCh<ExpectedSubj, StructSubj>()
+
+      type StandardSubj = NonNullable<
+        (typeof struct)['~standard']['types']
+      >['output']
+
+      x.tCh<StandardSubj, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardSubj>()
 
       /* parsed either type check */
 
@@ -717,6 +854,14 @@ describe('Compound schema specifics (foldA)', () => {
 
       x.tCh<StructParsed, ExpectedParsed>()
       x.tCh<ExpectedParsed, StructParsed>()
+
+      type StandardParsed = Extract<
+        ReturnType<(typeof struct)['~standard']['validate']>,
+        { value: unknown }
+      >['value']
+
+      x.tCh<StandardParsed, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardParsed>()
 
       /* runtime schema check */
 
@@ -741,6 +886,18 @@ describe('Compound schema specifics (foldA)', () => {
 
         expect(structParsed.error).toBe(undefined)
         expect(structParsed.data).toStrictEqual(subj)
+
+        const standardParsed = struct['~standard'].validate(subj)
+
+        if (standardParsed instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        if (standardParsed.issues !== undefined) {
+          throw Error('not expected')
+        }
+
+        expect(standardParsed.value).toStrictEqual(subj)
       }
     }
   })
@@ -767,7 +924,7 @@ describe('Compound schema specifics (foldA)', () => {
     foldA: {
       const construct = x.makeStruct(schema)
 
-      /* ensure that schema/construct/struct subject types are identical */
+      /* ensure that schema/construct/struct/~standard subject types are identical */
 
       type ConstructSchemaSubj = x.Infer<typeof construct.__schema>
 
@@ -783,6 +940,13 @@ describe('Compound schema specifics (foldA)', () => {
 
       x.tCh<StructSubj, ExpectedSubj>()
       x.tCh<ExpectedSubj, StructSubj>()
+
+      type StandardSubj = NonNullable<
+        (typeof struct)['~standard']['types']
+      >['output']
+
+      x.tCh<StandardSubj, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardSubj>()
 
       /* parsed either type check */
 
@@ -804,6 +968,14 @@ describe('Compound schema specifics (foldA)', () => {
 
       x.tCh<StructParsed, ExpectedParsed>()
       x.tCh<ExpectedParsed, StructParsed>()
+
+      type StandardParsed = Extract<
+        ReturnType<(typeof struct)['~standard']['validate']>,
+        { value: unknown }
+      >['value']
+
+      x.tCh<StandardParsed, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardParsed>()
 
       /* runtime schema check */
 
@@ -828,6 +1000,18 @@ describe('Compound schema specifics (foldA)', () => {
 
         expect(structParsed.error).toBe(undefined)
         expect(structParsed.data).toStrictEqual(subj)
+
+        const standardParsed = struct['~standard'].validate(subj)
+
+        if (standardParsed instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        if (standardParsed.issues !== undefined) {
+          throw Error('not expected')
+        }
+
+        expect(standardParsed.value).toStrictEqual(subj)
       }
     }
   })
@@ -857,7 +1041,7 @@ describe('Compound schema specifics (foldA)', () => {
     foldA: {
       const construct = x.makeStruct(schema)
 
-      /* ensure that schema/construct/struct subject types are identical */
+      /* ensure that schema/construct/struct/~standard subject types are identical */
 
       type ConstructSchemaSubj = x.Infer<typeof construct.__schema>
 
@@ -873,6 +1057,13 @@ describe('Compound schema specifics (foldA)', () => {
 
       x.tCh<StructSubj, ExpectedSubj>()
       x.tCh<ExpectedSubj, StructSubj>()
+
+      type StandardSubj = NonNullable<
+        (typeof struct)['~standard']['types']
+      >['output']
+
+      x.tCh<StandardSubj, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardSubj>()
 
       /* parsed either type check */
 
@@ -894,6 +1085,14 @@ describe('Compound schema specifics (foldA)', () => {
 
       x.tCh<StructParsed, ExpectedParsed>()
       x.tCh<ExpectedParsed, StructParsed>()
+
+      type StandardParsed = Extract<
+        ReturnType<(typeof struct)['~standard']['validate']>,
+        { value: unknown }
+      >['value']
+
+      x.tCh<StandardParsed, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardParsed>()
 
       /* runtime schema check */
 
@@ -918,6 +1117,18 @@ describe('Compound schema specifics (foldA)', () => {
 
         expect(structParsed.error).toBe(undefined)
         expect(structParsed.data).toStrictEqual(subj)
+
+        const standardParsed = struct['~standard'].validate(subj)
+
+        if (standardParsed instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        if (standardParsed.issues !== undefined) {
+          throw Error('not expected')
+        }
+
+        expect(standardParsed.value).toStrictEqual(subj)
       }
     }
   })
@@ -979,7 +1190,7 @@ describe('Compound schema specifics (foldA)', () => {
     foldA: {
       const construct = x.makeStruct(schema)
 
-      /* ensure that schema/construct/struct subject types are identical */
+      /* ensure that schema/construct/struct/~standard subject types are identical */
 
       type ConstructSchemaSubj = x.Infer<typeof construct.__schema>
 
@@ -995,6 +1206,13 @@ describe('Compound schema specifics (foldA)', () => {
 
       x.tCh<StructSubj, ExpectedSubj>()
       x.tCh<ExpectedSubj, StructSubj>()
+
+      type StandardSubj = NonNullable<
+        (typeof struct)['~standard']['types']
+      >['output']
+
+      x.tCh<StandardSubj, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardSubj>()
 
       /* parsed either type check */
 
@@ -1016,6 +1234,14 @@ describe('Compound schema specifics (foldA)', () => {
 
       x.tCh<StructParsed, ExpectedParsed>()
       x.tCh<ExpectedParsed, StructParsed>()
+
+      type StandardParsed = Extract<
+        ReturnType<(typeof struct)['~standard']['validate']>,
+        { value: unknown }
+      >['value']
+
+      x.tCh<StandardParsed, ExpectedSubj>()
+      x.tCh<ExpectedSubj, StandardParsed>()
 
       /* runtime schema check */
 
@@ -1040,6 +1266,18 @@ describe('Compound schema specifics (foldA)', () => {
 
         expect(structParsed.error).toBe(undefined)
         expect(structParsed.data).toStrictEqual(subj)
+
+        const standardParsed = struct['~standard'].validate(subj)
+
+        if (standardParsed instanceof Promise) {
+          throw Error('Not expected')
+        }
+
+        if (standardParsed.issues !== undefined) {
+          throw Error('not expected')
+        }
+
+        expect(standardParsed.value).toStrictEqual(subj)
       }
     }
   })

--- a/src/tests/type.ts
+++ b/src/tests/type.ts
@@ -1,0 +1,1 @@
+export type StructSharedKeys = '__schema' | '~standard' | 'parse'

--- a/src/types/standard-schema.ts
+++ b/src/types/standard-schema.ts
@@ -1,0 +1,50 @@
+export interface StandardSchemaV1<Input = unknown, Output = Input> {
+  /** Source: https://github.com/standard-schema/standard-schema/blob/main/packages/spec/src/index.ts */
+  readonly '~standard': StandardSchemaV1.Props<Input, Output>
+}
+
+export declare namespace StandardSchemaV1 {
+  export interface Props<Input = unknown, Output = Input> {
+    readonly version: 1
+    readonly vendor: string
+    readonly validate: (
+      value: unknown
+    ) => Result<Output> | Promise<Result<Output>>
+    readonly types?: Types<Input, Output> | undefined
+  }
+
+  export type Result<Output> = SuccessResult<Output> | FailureResult
+
+  export interface SuccessResult<Output> {
+    readonly value: Output
+    readonly issues?: undefined
+  }
+
+  export interface FailureResult {
+    readonly issues: ReadonlyArray<Issue>
+  }
+
+  export interface Issue {
+    readonly message: string
+    readonly path?: ReadonlyArray<PropertyKey | PathSegment> | undefined
+  }
+
+  export interface PathSegment {
+    readonly key: PropertyKey
+  }
+
+  export interface Types<Input = unknown, Output = Input> {
+    readonly input: Input
+    readonly output: Output
+  }
+
+  export type InferInput<Schema extends StandardSchemaV1> = NonNullable<
+    Schema['~standard']['types']
+  >['input']
+
+  export type InferOutput<Schema extends StandardSchemaV1> = NonNullable<
+    Schema['~standard']['types']
+  >['output']
+
+  export {}
+}

--- a/src/types/struct.ts
+++ b/src/types/struct.ts
@@ -1,5 +1,6 @@
 import { ParseResult } from './utils'
 
+import type { StandardSchemaV1 } from './standard-schema'
 import type {
   Schema,
   //
@@ -59,7 +60,7 @@ export type Struct<T extends Schema> = Omit<
 > & {
   __schema: Readonly<T>
   parse: (s: unknown) => ParseResult<InferSchema<T>>
-}
+} & StandardSchemaV1<unknown, InferSchema<T>>
 
 type BrandSubType =
   | boolean


### PR DESCRIPTION
This pull request introduces support for the [standard schema](https://standardschema.dev) interface to the `schematox` library, enabling compatibility with a common TypeScript validation ecosystem. The changes include a new `~standard` property on structs, providing a standardized validation method, and comprehensive updates to tests to verify type inference and validation behavior. Additionally, documentation and versioning have been updated to reflect these enhancements.

**Standard Schema Support:**

* Added a new `STANDARD_SCHEMA` constant and integrated it into the result of `makeStruct`, exposing a `~standard` property with a `validate` method that conforms to the standard schema interface. This method returns either a `value` on success or an array of `issues` on failure. (`src/constants.ts`, `src/struct.ts`) [[1]](diffhunk://#diff-8fa4b52909f895e8cda060d2035234e0a42ca2c7d3f8f8de1b35a056537bf199R19-R23) [[2]](diffhunk://#diff-68ce0c947ad687c708eb49dec4c744ce2559ccbf65c3b7d9aa9913ab3a535b36L1-R28)

**Documentation and Versioning:**

* Updated the `README.md` to highlight support for the standard schema and improved feature descriptions for clarity. (`README.md`)
* Bumped the package version to `1.1.0-alpha` in `package.json` to indicate the addition of new features. (`package.json`)

**Testing Enhancements:**

* Extended and refactored tests in `src/tests/README.md` and `src/tests/by-struct/array.test.ts` to verify that the new `~standard` property produces correct type inference and runtime validation results, including both success and error cases. (`src/tests/README.md`, `src/tests/by-struct/array.test.ts`) [[1]](diffhunk://#diff-0a640d3f09fb65be6b2a1f63092bed7eeb367ea85d030d1a7edbdfc650c89f2bL75-R75) [[2]](diffhunk://#diff-0a640d3f09fb65be6b2a1f63092bed7eeb367ea85d030d1a7edbdfc650c89f2bR92-R101) [[3]](diffhunk://#diff-0a640d3f09fb65be6b2a1f63092bed7eeb367ea85d030d1a7edbdfc650c89f2bR120-R127) [[4]](diffhunk://#diff-0a640d3f09fb65be6b2a1f63092bed7eeb367ea85d030d1a7edbdfc650c89f2bR151-R162) [[5]](diffhunk://#diff-0a640d3f09fb65be6b2a1f63092bed7eeb367ea85d030d1a7edbdfc650c89f2bR265-R274) [[6]](diffhunk://#diff-0a640d3f09fb65be6b2a1f63092bed7eeb367ea85d030d1a7edbdfc650c89f2bR311-R320) [[7]](diffhunk://#diff-0a640d3f09fb65be6b2a1f63092bed7eeb367ea85d030d1a7edbdfc650c89f2bR377-R386) [[8]](diffhunk://#diff-3e1e5734727b186470e05c751cd7bfe056ef04a84e04d3998ce94377812a4aedL23-R25) [[9]](diffhunk://#diff-3e1e5734727b186470e05c751cd7bfe056ef04a84e04d3998ce94377812a4aedR42-R48) [[10]](diffhunk://#diff-3e1e5734727b186470e05c751cd7bfe056ef04a84e04d3998ce94377812a4aedR70-R77) [[11]](diffhunk://#diff-3e1e5734727b186470e05c751cd7bfe056ef04a84e04d3998ce94377812a4aedR101-R112) [[12]](diffhunk://#diff-3e1e5734727b186470e05c751cd7bfe056ef04a84e04d3998ce94377812a4aedL108-R137) [[13]](diffhunk://#diff-3e1e5734727b186470e05c751cd7bfe056ef04a84e04d3998ce94377812a4aedR154-R160) [[14]](diffhunk://#diff-3e1e5734727b186470e05c751cd7bfe056ef04a84e04d3998ce94377812a4aedR182-R189) [[15]](diffhunk://#diff-3e1e5734727b186470e05c751cd7bfe056ef04a84e04d3998ce94377812a4aedR213-R224) [[16]](diffhunk://#diff-3e1e5734727b186470e05c751cd7bfe056ef04a84e04d3998ce94377812a4aedL189-R245) [[17]](diffhunk://#diff-3e1e5734727b186470e05c751cd7bfe056ef04a84e04d3998ce94377812a4aedR262-R268) [[18]](diffhunk://#diff-3e1e5734727b186470e05c751cd7bfe056ef04a84e04d3998ce94377812a4aedR290-R297) [[19]](diffhunk://#diff-3e1e5734727b186470e05c751cd7bfe056ef04a84e04d3998ce94377812a4aedR321-R332) [[20]](diffhunk://#diff-3e1e5734727b186470e05c751cd7bfe056ef04a84e04d3998ce94377812a4aedL273-R356) [[21]](diffhunk://#diff-3e1e5734727b186470e05c751cd7bfe056ef04a84e04d3998ce94377812a4aedR373-R379) [[22]](diffhunk://#diff-3e1e5734727b186470e05c751cd7bfe056ef04a84e04d3998ce94377812a4aedR401-R408) [[23]](diffhunk://#diff-3e1e5734727b186470e05c751cd7bfe056ef04a84e04d3998ce94377812a4aedR432-R443) [[24]](diffhunk://#diff-3e1e5734727b186470e05c751cd7bfe056ef04a84e04d3998ce94377812a4aedL357-R467) [[25]](diffhunk://#diff-3e1e5734727b186470e05c751cd7bfe056ef04a84e04d3998ce94377812a4aedR484-R490)

These changes ensure that `schematox` can be used seamlessly with other TypeScript validation libraries following the standard schema specification, and that its type inference and error reporting are robustly tested.