### PR TITLE
Record schema range limiters support

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,25 +315,29 @@ type FromStruct = Infer<typeof struct>
 
 ### Record
 
-Undefined record entries are skipped in parsed results. If a key exists, it means a value is also present.
+Undefined record entries are skipped in parsed results and ignored by range limiter counter. If a key exists, it means a value is also present.
 
 ```typescript
 const schema = {
   type: 'record',
-  // key property is optional
   key: { type: 'string', brand: ['idFor', 'user'] },
   of: { type: 'number' },
+  minLength: 1,
+  maxLength: 1,
   optional: true,
   nullable: true,
   description: 'x',
 } as const satisfies Schema
 
 const userId = string().brand('idFor', 'user')
+const struct = record(number(), userId)
+  .minLength(1)
+  .maxLength(1)
+  .optional()
+  .nullable()
+  .description('x')
 
-// second argument is optional
-const struct = object(number(), userId).optional().nullable().description('x')
-
-// Record<string & { __brand: ['idFor', 'user'] }, number | undefined>  | null | undefined
+// Record<string & { __brand: ['idFor', 'user'] }, number>  | null | undefined
 type FromSchema = Infer<typeof schema>
 type FromStruct = Infer<typeof struct>
 ```

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -12,7 +12,7 @@ export const PARAMS_BY_SCHEMA_TYPE = {
   //
   array:    new Set(['optional', 'nullable', 'description', 'minLength', 'maxLength'] as const),
   object:   new Set(['optional', 'nullable', 'description'] as const),
-  record:   new Set(['optional', 'nullable', 'description'] as const),
+  record:   new Set(['optional', 'nullable', 'description', 'minLength', 'maxLength'] as const),
   tuple:    new Set(['optional', 'nullable', 'description'] as const),
   union:    new Set(['optional', 'nullable', 'description'] as const),
 } as const

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -225,6 +225,20 @@ function parseArray(
     }
 
     result.push(parsed.data)
+
+    if (
+      typeof schema.maxLength === 'number' &&
+      result.length > schema.maxLength
+    ) {
+      return error([
+        {
+          code: ERROR_CODE.invalidRange,
+          path: errorPath,
+          subject,
+          schema,
+        },
+      ])
+    }
   }
 
   if (invalidSubjects?.length) {
@@ -234,20 +248,6 @@ function parseArray(
   if (
     typeof schema.minLength === 'number' &&
     result.length < schema.minLength
-  ) {
-    return error([
-      {
-        code: ERROR_CODE.invalidRange,
-        path: errorPath,
-        subject,
-        schema,
-      },
-    ])
-  }
-
-  if (
-    typeof schema.maxLength === 'number' &&
-    result.length > schema.maxLength
   ) {
     return error([
       {
@@ -337,6 +337,7 @@ function parseRecord(
 
   const result: Record<string, unknown> = {}
   let invalidSubjects: InvalidSubject[] | undefined
+  let validEntryCounter = 0
 
   for (const key in subject) {
     const nestedValue = (subject as Record<string, unknown>)[key]
@@ -358,7 +359,37 @@ function parseRecord(
       continue
     }
 
+    validEntryCounter++
+
+    if (
+      typeof schema.maxLength === 'number' &&
+      validEntryCounter > schema.maxLength
+    ) {
+      return error([
+        {
+          code: ERROR_CODE.invalidRange,
+          path: errorPath,
+          subject,
+          schema,
+        },
+      ])
+    }
+
     result[key] = parsed.data
+  }
+
+  if (
+    typeof schema.minLength === 'number' &&
+    validEntryCounter < schema.minLength
+  ) {
+    return error([
+      {
+        code: ERROR_CODE.invalidRange,
+        path: errorPath,
+        subject,
+        schema,
+      },
+    ])
   }
 
   if (invalidSubjects?.length) {

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -4,7 +4,7 @@ export type Schema =
    | PrimitiveSchema
    | { type: 'array'; of: Schema; minLength?: number; maxLength?: number } & SchemaShared
    | { type: 'object'; of: Record<string, Schema> } & SchemaShared
-   | { type: 'record'; of: Schema; key?: StringSchema } & SchemaShared
+   | { type: 'record'; of: Schema; key?: StringSchema; minLength?: number; maxLength?: number } & SchemaShared
    | { type: 'tuple'; of: Array<Schema> } & SchemaShared
    | { type: 'union'; of: Array<Schema> } & SchemaShared
 
@@ -48,6 +48,8 @@ export type RecordSchema<T = unknown> = SchemaShared & {
   type: 'record'
   of: T
   key?: StringSchema
+  minLength?: number /* >= */
+  maxLength?: number /* <= */
 }
 
 export type TupleSchema<T = unknown> = SchemaShared & {


### PR DESCRIPTION
Closes #47 

This pull request adds support for `minLength` and `maxLength` constraints to `record` schemas, aligning their behavior with `array` schemas. Now, you can specify the minimum and maximum number of defined entries in a record, and parsing will enforce these constraints. The changes include updates to the schema types, parsing logic, constants, documentation, and comprehensive new tests to ensure correct behavior and immutability.

**Schema and Parsing Enhancements:**

- Added `minLength` and `maxLength` as optional parameters to the `record` schema type definitions in both `Schema` and `RecordSchema`, enabling length constraints for records. [[1]](diffhunk://#diff-2811f460bc361ad5494018c987e0713a599a5cb1ee2f70abb3aa9b831492c6a1L7-R7) [[2]](diffhunk://#diff-2811f460bc361ad5494018c987e0713a599a5cb1ee2f70abb3aa9b831492c6a1R51-R52)
- Updated the parsing logic in `parseRecord` to count valid entries and enforce `minLength` and `maxLength` constraints, returning an `invalidRange` error if violated. [[1]](diffhunk://#diff-5440d8a745153fcd12ef76b1d6cb492751d2f997e6cde5d11234552341119c2aR340) [[2]](diffhunk://#diff-5440d8a745153fcd12ef76b1d6cb492751d2f997e6cde5d11234552341119c2aR362-R405)

**Constants and Documentation:**

- Extended `PARAMS_BY_SCHEMA_TYPE` to include `minLength` and `maxLength` for `record` schemas, ensuring these parameters are recognized as valid.
- Updated the `README.md` to document the new behavior, including examples and clarifications about how undefined record entries are handled by the range limiter.

**Testing Improvements:**

- Expanded and added tests in `record.test.ts` to verify key reduction, schema immutability, and correct error handling for `minLength` and `maxLength` constraints on records, including edge cases and runtime checks. [[1]](diffhunk://#diff-ffd377b71d01e6bf13f59c36c5502e1399178b105957523b0bc32c5a3e48140bL572-R577) [[2]](diffhunk://#diff-ffd377b71d01e6bf13f59c36c5502e1399178b105957523b0bc32c5a3e48140bR630-R743) [[3]](diffhunk://#diff-ffd377b71d01e6bf13f59c36c5502e1399178b105957523b0bc32c5a3e48140bL667-R803) [[4]](diffhunk://#diff-ffd377b71d01e6bf13f59c36c5502e1399178b105957523b0bc32c5a3e48140bL721-R862) [[5]](diffhunk://#diff-ffd377b71d01e6bf13f59c36c5502e1399178b105957523b0bc32c5a3e48140bR1052-R1194)