### PR TITLE
fix: loosen object()/record() type check; drop subject from errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- FIX: `object()`/`record()` rejected valid plain objects that aren't `instanceof Object` in the strict identity sense (e.g. `process.env` under Node, `Object.create(null)`, cross-realm objects). The type check now uses `Object.prototype.toString.call(subject) === '[object Object]'`, which still rejects `Map`/`Set`/`Error`/typed arrays/other built-ins.
+- BREAKING: removed the `subject` field from `InvalidSubject` (the shape of `ParseError['error']` entries). It echoed the raw parsed input value into validation errors, which could leak sensitive data (e.g. secrets from `process.env`) when errors are logged/serialized. `code`, `path`, and `schema` remain.
+
 ## [1.3.1](https://github.com/incerta/schematox/compare/v1.3.0...v1.3.1)
 
 - [Modernize schematox ESM TypeScript build and test setup #58](https://github.com/incerta/schematox/pull/67)

--- a/README.md
+++ b/README.md
@@ -316,6 +316,8 @@ type FromStruct = Infer<typeof struct>
 Extra properties in the parsed subject that are not specified in the `object` schema will not cause an error and will be skipped.
 This is a deliberate decision that allows client schemas to remain functional whenever the API is extended.
 
+Any plain object is accepted as a subject, including ones without `Object.prototype` in their chain (`Object.create(null)`) or ones backed by a native binding (e.g. `process.env`). `Map`, `Set`, `Error`, typed arrays, and other non-plain-object built-ins are rejected.
+
 ```typescript
 const schema = {
   type: 'object',
@@ -344,6 +346,8 @@ type FromStruct = Infer<typeof struct>
 ### Record
 
 Undefined record entries are skipped in parsed results and ignored by range limiter counter. If a key exists, it means a value is also present.
+
+Like `object`, any plain object is accepted as a subject (including `Object.create(null)` and native-bound objects like `process.env`); `Map`, `Set`, `Error`, typed arrays, and similar built-ins are rejected.
 
 ```typescript
 const schema = {
@@ -450,7 +454,6 @@ The `result.error` shape is:
     "code": "INVALID_TYPE",
     "path": ["x", "y", 0, "z"]
     "schema": { "type": "string" },
-    "subject": 0,
   }
 ]
 ```
@@ -461,5 +464,6 @@ It's always an array of `InvalidSubject` entries, each has the following propert
   - `INVALID_TYPE`: schema subject or default value don't meet schema type specifications
   - `INVALID_RANGE`: `min/max` or `minLength/maxLength` schema requirements aren't met
 - `schema`: the specific section of `schema` where the invalid value is found.
-- `subject`: the specific part of the validated subject where the invalid value exists.
 - `path`: traces the route from the root to the error subject, with strings as keys and numbers as array indexes.
+
+Note: the parsed input itself is intentionally **not** included in the error — only the schema fragment and path. This prevents sensitive data (e.g. secrets from `process.env`) from ending up in logs when errors are serialized (`JSON.stringify(result.error)`).

--- a/README.md
+++ b/README.md
@@ -1,16 +1,18 @@
 # Schematox
 
-Schematox is a lightweight typesafe schema defined parser. All schemas are JSON compatible.
+**A typesafe schema that's also just data.**
 
-The library is focusing on fixed set of schema types: bigint, boolean, literal, number, string, array, object, record, tuple, union. Each schema can have parameters: optional, nullable, description. Each primitive schema has "brand" parameter as mean of making its subject type [nominal](https://github.com/Microsoft/TypeScript/wiki/FAQ#can-i-make-a-type-alias-nominal). The rest parameters is schema specific range limiters.
+[![npm version](https://img.shields.io/npm/v/schematox.svg)](https://www.npmjs.com/package/schematox)
+[![npm downloads](https://img.shields.io/npm/dm/schematox.svg)](https://www.npmjs.com/package/schematox)
+[![bundle size](https://img.shields.io/bundlephobia/minzip/schematox)](https://bundlephobia.com/package/schematox)
+[![dependencies](https://img.shields.io/badge/dependencies-0-brightgreen)](https://www.npmjs.com/package/schematox)
+[![license](https://img.shields.io/npm/l/schematox.svg)](./LICENSE)
 
-Library supports static schema definition which means your schemas could be completely independent from schematox. One could use such schemas as source for generation other structures like DB models.
-
-The library is small so exploring README.md is enough for understanding its API, checkout [examples](#quick-start) and you good to go:
+Most TypeScript validators (Zod, Yup, Joi) make you build a schema out of function calls, which means the schema only exists as code you import. Schematox schemas are plain JSON objects that structurally satisfy a `Schema` type — so the same schema can be serialized, stored in a database, sent over the wire, diffed between versions, or generated from another source of truth, in addition to being usable directly as a typesafe parser. You still get a familiar chainable `struct` builder (à la Zod) if you'd rather write schemas as code — both approaches produce the exact same JSON underneath.
 
 - [Install](#install)
 - [Minimal Requirements](#minimal-requirements)
-- [Features](#features)
+- [Why Schematox?](#why-schematox)
 - [Quick Start](#quick-start)
   - [Static Schema](#static-schema)
   - [Struct](#struct)
@@ -41,15 +43,15 @@ npm install schematox
 - ECMAScript version: `2020`
 - TypeScript version: `5.3.2`
 
-## Features
+## Why Schematox?
 
-- Statically defined **JSON** compatible schema (easy to serialize/deserialize/generate/store/transfer)
-- Programmatically defined schema (**struct**, **construct**)
-- Check defined schema correctness using non generic type **Schema**
-- Ether-style error handling (no unexpected throws)
-- First-class support for branded primitives (primitive nominal types alias)
-- Construct type requirement for schema itself using exposed type generics
-- Support the [standard schema](https://standardschema.dev) - a common interface for TypeScript validation libraries
+- **Schemas are data, not just code.** A schema is a plain JSON object that structurally satisfies the `Schema` type — no function calls required. Store it, transfer it, generate it, diff it, or use it as the source of truth for other structures like DB models.
+- **Zero dependencies.** Nothing to audit, nothing to update out from under you.
+- **Small enough to read.** The whole library is ~1,200 lines of TypeScript — you can read it end to end instead of trusting a black box.
+- **Either-style error handling.** `parse()` never throws. You always get `{ success, data, error }` back and decide what happens next.
+- **Branded primitives, first-class.** Nominal typing (`string & { __idFor: 'User' }`) is built in, not bolted on.
+- **[Standard Schema](https://standardschema.dev) compliant.** Works with any tool built against the shared validation interface used by Zod, Valibot, and others.
+- **100% test coverage, enforced.** Statements, branches, functions, and lines — every release is gated on it.
 
 ## Quick Start
 

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -43,6 +43,7 @@ export function parse(schema: Schema, subject: unknown): ParseResult<unknown> {
   return parseRecursively([], schema, subject)
 }
 
+// Recursion depth follows the static schema's nesting, never the subject's, so untrusted input can't drive stack depth.
 function parseRecursively(
   errorPath: ErrorPath,
   schema: Schema,
@@ -73,7 +74,6 @@ function parseBigInt(
       {
         code: ERROR_CODE.invalidType,
         path: errorPath,
-        subject,
         schema,
       },
     ])
@@ -87,7 +87,6 @@ function parseBigInt(
         {
           code: ERROR_CODE.invalidRange,
           path: errorPath,
-          subject,
           schema,
         },
       ])
@@ -102,7 +101,6 @@ function parseBigInt(
         {
           code: ERROR_CODE.invalidRange,
           path: errorPath,
-          subject,
           schema,
         },
       ])
@@ -122,7 +120,6 @@ function parseBoolean(
       {
         code: ERROR_CODE.invalidType,
         path: errorPath,
-        subject,
         schema,
       },
     ])
@@ -141,7 +138,6 @@ function parseLiteral(
       {
         code: ERROR_CODE.invalidType,
         path: errorPath,
-        subject,
         schema,
       },
     ])
@@ -160,7 +156,6 @@ function parseNumber(
       {
         code: ERROR_CODE.invalidType,
         path: errorPath,
-        subject,
         schema,
       },
     ])
@@ -172,7 +167,6 @@ function parseNumber(
         {
           code: ERROR_CODE.invalidRange,
           path: errorPath,
-          subject,
           schema,
         },
       ])
@@ -185,7 +179,6 @@ function parseNumber(
         {
           code: ERROR_CODE.invalidRange,
           path: errorPath,
-          subject,
           schema,
         },
       ])
@@ -205,7 +198,6 @@ function parseString(
       {
         code: ERROR_CODE.invalidType,
         path: errorPath,
-        subject,
         schema,
       },
     ])
@@ -217,7 +209,6 @@ function parseString(
         {
           code: ERROR_CODE.invalidRange,
           path: errorPath,
-          subject,
           schema,
         },
       ])
@@ -230,7 +221,6 @@ function parseString(
         {
           code: ERROR_CODE.invalidRange,
           path: errorPath,
-          subject,
           schema,
         },
       ])
@@ -250,7 +240,6 @@ function parseArray(
       {
         code: ERROR_CODE.invalidType,
         path: errorPath,
-        subject,
         schema,
       },
     ])
@@ -285,7 +274,6 @@ function parseArray(
         {
           code: ERROR_CODE.invalidRange,
           path: errorPath,
-          subject,
           schema,
         },
       ])
@@ -304,7 +292,6 @@ function parseArray(
       {
         code: ERROR_CODE.invalidRange,
         path: errorPath,
-        subject,
         schema,
       },
     ])
@@ -321,14 +308,13 @@ function parseObject(
   if (
     typeof subject !== 'object' ||
     subject === null ||
-    subject.constructor !== Object
+    Object.prototype.toString.call(subject) !== '[object Object]'
   ) {
     return error([
       {
         code: ERROR_CODE.invalidType,
         path: errorPath,
         schema,
-        subject,
       },
     ])
   }
@@ -374,14 +360,13 @@ function parseRecord(
   if (
     typeof subject !== 'object' ||
     subject === null ||
-    subject.constructor !== Object
+    Object.prototype.toString.call(subject) !== '[object Object]'
   ) {
     return error([
       {
         code: ERROR_CODE.invalidType,
         path: errorPath,
         schema,
-        subject,
       },
     ])
   }
@@ -420,7 +405,6 @@ function parseRecord(
         {
           code: ERROR_CODE.invalidRange,
           path: errorPath,
-          subject,
           schema,
         },
       ])
@@ -437,7 +421,6 @@ function parseRecord(
       {
         code: ERROR_CODE.invalidRange,
         path: errorPath,
-        subject,
         schema,
       },
     ])
@@ -460,7 +443,6 @@ function parseTuple(
       {
         code: ERROR_CODE.invalidType,
         path: errorPath,
-        subject,
         schema,
       },
     ])
@@ -512,7 +494,6 @@ function parseUnion(
     {
       code: ERROR_CODE.invalidType,
       path: errorPath,
-      subject,
       schema,
     },
   ])

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -17,25 +17,11 @@ export type ParseSuccess<T> = {
 export type InvalidSubject = {
   code: ErrorCode
 
-  /**
-   * Path to the invalid data, represented as an array of object keys (strings)
-   * and array indices (numbers) that can be used to navigate to the specific
-   * location where validation failed
-   **/
+  /** Path to the invalid data: object keys and array indices from the root */
   path: ErrorPath
 
-  /**
-   * The specific part of the schema definition that was used to validate
-   * the subject data (not necessarily the overall schema, but the schema
-   * fragment that caused the validation failure)
-   **/
+  /** The schema fragment that the invalid data failed to satisfy */
   schema: Schema
-
-  /**
-   * The specific data value that failed validation (not necessarily the
-   * entire input, but the particular piece of data that caused the issue)
-   **/
-  subject: unknown
 }
 
 export type ErrorCode = 'INVALID_TYPE' | 'INVALID_RANGE'

--- a/tests/README.md
+++ b/tests/README.md
@@ -250,7 +250,6 @@ it('iterate over fixture.DATA_TYPE', () => {
           {
             code: x.ERROR_CODE.invalidType,
             schema: schema,
-            subject: subject,
             path: [],
           },
         ]
@@ -296,7 +295,6 @@ it('min', () => {
         {
           code: x.ERROR_CODE.invalidRange,
           schema: schema,
-          subject: subject,
           path: [],
         },
       ]
@@ -357,13 +355,12 @@ it('InvalidSubject error of nested schema should have correct path/schema/subjec
   foldE: {
     const construct = x.makeStruct(schema)
 
-    for (const [subject, invalidSubj, invalidSubjSchema, path] of samples) {
+    for (const [subject, , invalidSubjSchema, path] of samples) {
       const expectedError = [
         {
           path,
           code: x.ERROR_CODE.invalidType,
           schema: invalidSubjSchema,
-          subject: invalidSubj,
         },
       ]
 

--- a/tests/by-struct/array.test.ts
+++ b/tests/by-struct/array.test.ts
@@ -1049,7 +1049,6 @@ describe('ERROR_CODE.invalidType (foldC, foldE)', () => {
             {
               code: x.ERROR_CODE.invalidType,
               schema: schema,
-              subject: subject,
               path: [],
             },
           ]
@@ -1105,13 +1104,12 @@ describe('ERROR_CODE.invalidType (foldC, foldE)', () => {
     foldE: {
       const construct = x.makeStruct(schema)
 
-      for (const [subject, invalidSubj, invalidSubjSchema, path] of samples) {
+      for (const [subject, , invalidSubjSchema, path] of samples) {
         const expectedError = [
           {
             path,
             code: x.ERROR_CODE.invalidType,
             schema: invalidSubjSchema,
-            subject: invalidSubj,
           },
         ]
 
@@ -1153,13 +1151,11 @@ describe('ERROR_CODE.invalidType (foldC, foldE)', () => {
         code: x.ERROR_CODE.invalidType,
         path: [0],
         schema: schema.of,
-        subject: null,
       },
       {
         code: x.ERROR_CODE.invalidType,
         path: [2],
         schema: schema.of,
-        subject: undefined,
       },
     ]
 
@@ -1192,7 +1188,6 @@ describe('ERROR_CODE.invalidRange (foldD)', () => {
           {
             code: x.ERROR_CODE.invalidRange,
             schema: schema,
-            subject: subject,
             path: [],
           },
         ]
@@ -1236,7 +1231,6 @@ describe('ERROR_CODE.invalidRange (foldD)', () => {
           {
             code: x.ERROR_CODE.invalidRange,
             schema: schema,
-            subject: subject,
             path: [],
           },
         ]
@@ -1285,7 +1279,6 @@ describe('ERROR_CODE.invalidRange (foldD)', () => {
           {
             code: x.ERROR_CODE.invalidRange,
             schema: schema,
-            subject: subject,
             path: [],
           },
         ]
@@ -1674,5 +1667,15 @@ describe('Compound schema specifics (foldA)', () => {
         expect(standardParsed.value).toStrictEqual(subj)
       }
     }
+  })
+
+  it('subject breadth does not grow recursion depth (parsing is iterative over elements, not recursive)', () => {
+    const struct = x.array(x.string())
+    const subject = new Array(200_000).fill('x')
+
+    const parsed = struct.parse(subject)
+
+    expect(parsed.error).toBe(undefined)
+    expect(parsed.data?.length).toBe(200_000)
   })
 })

--- a/tests/by-struct/bigint.test.ts
+++ b/tests/by-struct/bigint.test.ts
@@ -1083,7 +1083,6 @@ describe('ERROR_CODE.invalidType (foldC)', () => {
             {
               code: x.ERROR_CODE.invalidType,
               schema: schema,
-              subject: subject,
               path: [],
             },
           ]
@@ -1125,7 +1124,6 @@ describe('ERROR_CODE.invalidRange (foldD)', () => {
           {
             code: x.ERROR_CODE.invalidRange,
             schema: schema,
-            subject: subject,
             path: [],
           },
         ]
@@ -1164,7 +1162,6 @@ describe('ERROR_CODE.invalidRange (foldD)', () => {
           {
             code: x.ERROR_CODE.invalidRange,
             schema: schema,
-            subject: subject,
             path: [],
           },
         ]
@@ -1203,7 +1200,6 @@ describe('ERROR_CODE.invalidRange (foldD)', () => {
           {
             code: x.ERROR_CODE.invalidRange,
             schema: schema,
-            subject: subject,
             path: [],
           },
         ]

--- a/tests/by-struct/boolean.test.ts
+++ b/tests/by-struct/boolean.test.ts
@@ -713,7 +713,6 @@ describe('ERROR_CODE.invalidType (foldC)', () => {
             {
               code: x.ERROR_CODE.invalidType,
               schema: schema,
-              subject: subject,
               path: [],
             },
           ]

--- a/tests/by-struct/literal.test.ts
+++ b/tests/by-struct/literal.test.ts
@@ -727,7 +727,6 @@ describe('ERROR_CODE.invalidType (foldC)', () => {
             {
               code: x.ERROR_CODE.invalidType,
               schema: schema,
-              subject: subject,
               path: [],
             },
           ]

--- a/tests/by-struct/number.test.ts
+++ b/tests/by-struct/number.test.ts
@@ -1078,7 +1078,6 @@ describe('ERROR_CODE.invalidType (foldC)', () => {
             {
               code: x.ERROR_CODE.invalidType,
               schema: schema,
-              subject: subject,
               path: [],
             },
           ]
@@ -1120,7 +1119,6 @@ describe('ERROR_CODE.invalidRange (foldD)', () => {
           {
             code: x.ERROR_CODE.invalidRange,
             schema: schema,
-            subject: subject,
             path: [],
           },
         ]
@@ -1159,7 +1157,6 @@ describe('ERROR_CODE.invalidRange (foldD)', () => {
           {
             code: x.ERROR_CODE.invalidRange,
             schema: schema,
-            subject: subject,
             path: [],
           },
         ]
@@ -1198,7 +1195,6 @@ describe('ERROR_CODE.invalidRange (foldD)', () => {
           {
             code: x.ERROR_CODE.invalidRange,
             schema: schema,
-            subject: subject,
             path: [],
           },
         ]

--- a/tests/by-struct/object.test.ts
+++ b/tests/by-struct/object.test.ts
@@ -680,7 +680,6 @@ describe('ERROR_CODE.invalidType (foldC, foldE)', () => {
             {
               code: x.ERROR_CODE.invalidType,
               schema: schema,
-              subject: subject,
               path: [],
             },
           ]
@@ -743,13 +742,12 @@ describe('ERROR_CODE.invalidType (foldC, foldE)', () => {
     foldE: {
       const construct = x.makeStruct(schema)
 
-      for (const [subject, invalidSubj, invalidSubjSchema, path] of samples) {
+      for (const [subject, , invalidSubjSchema, path] of samples) {
         const expectedError = [
           {
             path,
             code: x.ERROR_CODE.invalidType,
             schema: invalidSubjSchema,
-            subject: invalidSubj,
           },
         ]
 
@@ -799,13 +797,11 @@ describe('ERROR_CODE.invalidType (foldC, foldE)', () => {
         code: x.ERROR_CODE.invalidType,
         path: ['x'],
         schema: schema.of.x,
-        subject: undefined,
       },
       {
         code: x.ERROR_CODE.invalidType,
         path: ['y'],
         schema: schema.of.y,
-        subject: null,
       },
     ]
 
@@ -816,6 +812,33 @@ describe('ERROR_CODE.invalidType (foldC, foldE)', () => {
     expect(parsedSchema.error).toStrictEqual(expectedError)
     expect(parsedStruct.error).toStrictEqual(expectedError)
     expect(parsedConstruct.error).toStrictEqual(expectedError)
+  })
+
+  it('accepts plain objects whose constructor is not `Object` (e.g. `Object.create(null)`, cross-realm/native-bound objects), while still rejecting Map/Set/Error/typed arrays', () => {
+    const struct = x.object({ x: x.string() })
+
+    const nullProtoSubject = Object.create(null) as Record<string, unknown>
+    nullProtoSubject['x'] = 'y'
+
+    expect(nullProtoSubject.constructor).toBe(undefined)
+    expect(struct.parse(nullProtoSubject).data).toStrictEqual({ x: 'y' })
+
+    class Foo {}
+    const customConstructorSubject = Object.assign(new Foo(), { x: 'y' })
+
+    expect(customConstructorSubject.constructor).not.toBe(Object)
+    expect(struct.parse(customConstructorSubject).data).toStrictEqual({
+      x: 'y',
+    })
+
+    for (const subject of [
+      new Map(),
+      new Set(),
+      new Error(),
+      new Int8Array(),
+    ]) {
+      expect(struct.parse(subject).error).toBeTruthy()
+    }
   })
 })
 
@@ -1323,7 +1346,6 @@ describe('Compound schema specifics (foldA)', () => {
          '38','39','40','41','42','43','44','45','46','47','48','49','50',
          'x'
         ],
-        subject: 0,
       },
     ]
 
@@ -1481,5 +1503,20 @@ describe('Compound schema specifics (foldA)', () => {
         expect(standardParsed.value).toStrictEqual(subj)
       }
     }
+  })
+
+  it('an extra key not declared in the schema is never traversed, even if its value is pathologically deep', () => {
+    const struct = x.object({ a: x.string() })
+
+    let deeplyNested: unknown = { leaf: true }
+
+    for (let i = 0; i < 200_000; i++) {
+      deeplyNested = { nested: deeplyNested }
+    }
+
+    const parsed = struct.parse({ a: 'value', extra: deeplyNested })
+
+    expect(parsed.error).toBe(undefined)
+    expect(parsed.data).toStrictEqual({ a: 'value' })
   })
 })

--- a/tests/by-struct/record.test.ts
+++ b/tests/by-struct/record.test.ts
@@ -1209,7 +1209,6 @@ describe('ERROR_CODE.invalidType (foldC, foldE)', () => {
             {
               code: x.ERROR_CODE.invalidType,
               schema: schema,
-              subject: subject,
               path: [],
             },
           ]
@@ -1268,13 +1267,12 @@ describe('ERROR_CODE.invalidType (foldC, foldE)', () => {
     foldE: {
       const construct = x.makeStruct(schema)
 
-      for (const [subject, invalidSubj, invalidSubjSchema, path] of samples) {
+      for (const [subject, , invalidSubjSchema, path] of samples) {
         const expectedError = [
           {
             path,
             code: x.ERROR_CODE.invalidType,
             schema: invalidSubjSchema,
-            subject: invalidSubj,
           },
         ]
 
@@ -1312,18 +1310,43 @@ describe('ERROR_CODE.invalidType (foldC, foldE)', () => {
       {
         code: x.ERROR_CODE.invalidType,
         path: ['y'],
-        subject: subject.y,
         schema: schema.of,
       },
       {
         code: x.ERROR_CODE.invalidType,
         path: ['z'],
-        subject: subject.z,
         schema: schema.of,
       },
     ]
 
     expect(parsed.error).toStrictEqual(expectedError)
+  })
+
+  it('accepts plain objects whose constructor is not `Object` (e.g. `Object.create(null)`, cross-realm/native-bound objects), while still rejecting Map/Set/Error/typed arrays', () => {
+    const struct = x.record(x.string())
+
+    const nullProtoSubject = Object.create(null) as Record<string, unknown>
+    nullProtoSubject['x'] = 'y'
+
+    expect(nullProtoSubject.constructor).toBe(undefined)
+    expect(struct.parse(nullProtoSubject).data).toStrictEqual({ x: 'y' })
+
+    class Foo {}
+    const customConstructorSubject = Object.assign(new Foo(), { x: 'y' })
+
+    expect(customConstructorSubject.constructor).not.toBe(Object)
+    expect(struct.parse(customConstructorSubject).data).toStrictEqual({
+      x: 'y',
+    })
+
+    for (const subject of [
+      new Map(),
+      new Set(),
+      new Error(),
+      new Int8Array(),
+    ]) {
+      expect(struct.parse(subject).error).toBeTruthy()
+    }
   })
 })
 
@@ -1351,7 +1374,6 @@ describe('ERROR_CODE.invalidRange (foldD)', () => {
           {
             code: x.ERROR_CODE.invalidRange,
             schema: schema,
-            subject: subject,
             path: [],
           },
         ]
@@ -1399,7 +1421,6 @@ describe('ERROR_CODE.invalidRange (foldD)', () => {
           {
             code: x.ERROR_CODE.invalidRange,
             schema: schema,
-            subject: subject,
             path: [],
           },
         ]
@@ -1448,7 +1469,6 @@ describe('ERROR_CODE.invalidRange (foldD)', () => {
           {
             code: x.ERROR_CODE.invalidRange,
             schema: schema,
-            subject: subject,
             path: [],
           },
         ]
@@ -1848,5 +1868,39 @@ describe('Compound schema specifics (foldA)', () => {
         expect(standardParsed.value).toStrictEqual(subj)
       }
     }
+  })
+
+  it('subject breadth does not grow recursion depth (parsing is iterative over keys, not recursive)', () => {
+    const struct = x.record(x.string())
+    const subject: Record<string, string> = {}
+
+    for (let i = 0; i < 200_000; i++) {
+      subject['k' + i] = 'v'
+    }
+
+    const parsed = struct.parse(subject)
+
+    expect(parsed.error).toBe(undefined)
+    expect(Object.keys(parsed.data ?? {}).length).toBe(200_000)
+  })
+
+  it('a deeply nested value that fails the value schema is rejected immediately, without recursing into its structure', () => {
+    const struct = x.record(x.string())
+
+    let deeplyNested: unknown = { leaf: true }
+
+    for (let i = 0; i < 200_000; i++) {
+      deeplyNested = { nested: deeplyNested }
+    }
+
+    const parsed = struct.parse({ x: deeplyNested })
+
+    expect(parsed.error).toStrictEqual([
+      {
+        code: x.ERROR_CODE.invalidType,
+        path: ['x'],
+        schema: { type: 'string' },
+      },
+    ])
   })
 })

--- a/tests/by-struct/string.test.ts
+++ b/tests/by-struct/string.test.ts
@@ -1089,7 +1089,6 @@ describe('ERROR_CODE.invalidType (foldC)', () => {
             {
               code: x.ERROR_CODE.invalidType,
               schema: schema,
-              subject: subject,
               path: [],
             },
           ]
@@ -1131,7 +1130,6 @@ describe('ERROR_CODE.invalidRange (foldD)', () => {
           {
             code: x.ERROR_CODE.invalidRange,
             schema: schema,
-            subject: subject,
             path: [],
           },
         ]
@@ -1170,7 +1168,6 @@ describe('ERROR_CODE.invalidRange (foldD)', () => {
           {
             code: x.ERROR_CODE.invalidRange,
             schema: schema,
-            subject: subject,
             path: [],
           },
         ]
@@ -1218,7 +1215,6 @@ describe('ERROR_CODE.invalidRange (foldD)', () => {
           {
             code: x.ERROR_CODE.invalidRange,
             schema: schema,
-            subject: subject,
             path: [],
           },
         ]

--- a/tests/by-struct/tuple.test.ts
+++ b/tests/by-struct/tuple.test.ts
@@ -691,7 +691,6 @@ describe('ERROR_CODE.invalidType (foldC, foldE)', () => {
             {
               code: x.ERROR_CODE.invalidType,
               schema: schema,
-              subject: subject,
               path: [],
             },
           ]
@@ -755,13 +754,12 @@ describe('ERROR_CODE.invalidType (foldC, foldE)', () => {
     foldE: {
       const construct = x.makeStruct(schema)
 
-      for (const [subject, invalidSubj, invalidSubjSchema, path] of samples) {
+      for (const [subject, , invalidSubjSchema, path] of samples) {
         const expectedError = [
           {
             path,
             code: x.ERROR_CODE.invalidType,
             schema: invalidSubjSchema,
-            subject: invalidSubj,
           },
         ]
 
@@ -803,13 +801,11 @@ describe('ERROR_CODE.invalidType (foldC, foldE)', () => {
         code: x.ERROR_CODE.invalidType,
         path: [0],
         schema: schema.of[0],
-        subject: 'A',
       },
       {
         code: x.ERROR_CODE.invalidType,
         path: [1],
         schema: schema.of[1],
-        subject: 'B',
       },
     ]
 

--- a/tests/by-struct/union.test.ts
+++ b/tests/by-struct/union.test.ts
@@ -685,7 +685,6 @@ describe('ERROR_CODE.invalidType (foldC, foldE)', () => {
             {
               code: x.ERROR_CODE.invalidType,
               schema: schema,
-              subject: subject,
               path: [],
             },
           ]
@@ -744,13 +743,12 @@ describe('ERROR_CODE.invalidType (foldC, foldE)', () => {
     foldE: {
       const construct = x.makeStruct(schema)
 
-      for (const [subject, invalidSubj, invalidSubjSchema, path] of samples) {
+      for (const [subject, , invalidSubjSchema, path] of samples) {
         const expectedError = [
           {
             path,
             code: x.ERROR_CODE.invalidType,
             schema: invalidSubjSchema,
-            subject: invalidSubj,
           },
         ]
 

--- a/tests/fold-constants.ts
+++ b/tests/fold-constants.ts
@@ -146,7 +146,6 @@ const FOLD_C = `{
         {
           code: x.ERROR_CODE.invalidType,
           schema: schema,
-          subject: subject,
           path: [],
         },
       ]
@@ -180,7 +179,6 @@ const FOLD_D = `{
       {
         code: x.ERROR_CODE.invalidRange,
         schema: schema,
-        subject: subject,
         path: [],
       },
     ]
@@ -208,13 +206,12 @@ const FOLD_D = `{
 const FOLD_E = `{
   const construct = x.makeStruct(schema)
 
-  for (const [subject, invalidSubj, invalidSubjSchema, path] of samples) {
+  for (const [subject, , invalidSubjSchema, path] of samples) {
     const expectedError = [
       {
         path,
         code: x.ERROR_CODE.invalidType,
         schema: invalidSubjSchema,
-        subject: invalidSubj,
       },
     ]
 

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -166,7 +166,6 @@ describe('Check ParseResult utilities', () => {
         code: x.ERROR_CODE.invalidType,
         path: [],
         schema: { type: 'string' },
-        subject: undefined,
       },
     ]
 


### PR DESCRIPTION
## Summary
- `object()`/`record()` rejected valid non-literal plain objects — e.g. `process.env`
  under Node, `Object.create(null)`, cross-realm objects — because the type guard used
  identity (`subject.constructor !== Object`) instead of duck-typing. Switched to
  `Object.prototype.toString.call(subject) === '[object Object]'`, which still rejects
  `Map`/`Set`/`Error`/typed arrays and other non-plain-object built-ins.
- **Breaking:** removed the `subject` field from `InvalidSubject`. It echoed the raw
  parsed input into every validation error, so logging a failed parse
  (e.g. `JSON.stringify(result.error)`) could leak secrets straight out of
  `process.env`. `code`, `path`, and `schema` remain.
- Added a comment documenting that parser recursion depth tracks the schema's static
  nesting, never the subject's — verified this holds even under pathologically deep/wide
  untrusted input (200k-level nesting, 200k keys/elements).

## Test plan
- [x] `npm run ts` — clean
- [x] `npx vitest run` — 272/272 passing
- [x] `npx prettier --check .` — clean
- [x] New regression coverage in `tests/by-struct/object.test.ts` and `record.test.ts`:
      accepts `Object.create(null)` / custom-constructor subjects, still rejects
      `Map`/`Set`/`Error`/typed arrays, deeply-nested unmatched/mismatched data is never
      traversed, and breadth (many keys/elements) doesn't grow recursion depth.
- [x] Docs updated: `README.md`, `CHANGELOG.md`, `tests/README.md`