### PR TITLE
perf: benchmark against similar libraries, then close the gap on object/array parsing

### DIFF
--- a/benchmark/adapters.ts
+++ b/benchmark/adapters.ts
@@ -9,7 +9,10 @@ export type LibKey = 'tox' | 'zod' | 'sup' | 'val' | 'ajv' | 'yup'
 // valibot/ajv all have one) — yup doesn't, so its adapter wraps the
 // throwing validateSync() in a try/catch, which is a real, fair difference
 // in cost between libraries, not something to hide by picking an unusual API.
-export const adapters: Record<LibKey, (schema: any, subject: unknown) => boolean> = {
+export const adapters: Record<
+  LibKey,
+  (schema: any, subject: unknown) => boolean
+> = {
   tox: (schema, subject) => schema.parse(subject).success,
   zod: (schema, subject) => schema.safeParse(subject).success,
   sup: (schema, subject) => sup.validate(subject, schema)[0] === undefined,

--- a/benchmark/adapters.ts
+++ b/benchmark/adapters.ts
@@ -1,0 +1,35 @@
+import * as sup from 'superstruct'
+import * as v from 'valibot'
+
+export type LibKey = 'tox' | 'zod' | 'sup' | 'val' | 'ajv' | 'yup'
+
+// Normalizes each library's validate/parse call to a single boolean, so the
+// benchmark runner can treat every library uniformly. Each adapter uses that
+// library's own non-throwing API where one exists (schematox/zod/superstruct/
+// valibot/ajv all have one) — yup doesn't, so its adapter wraps the
+// throwing validateSync() in a try/catch, which is a real, fair difference
+// in cost between libraries, not something to hide by picking an unusual API.
+export const adapters: Record<LibKey, (schema: any, subject: unknown) => boolean> = {
+  tox: (schema, subject) => schema.parse(subject).success,
+  zod: (schema, subject) => schema.safeParse(subject).success,
+  sup: (schema, subject) => sup.validate(subject, schema)[0] === undefined,
+  val: (schema, subject) => v.safeParse(schema, subject).success,
+  ajv: (schema, subject) => schema(subject) === true,
+  yup: (schema, subject) => {
+    try {
+      schema.validateSync(subject)
+      return true
+    } catch {
+      return false
+    }
+  },
+}
+
+export const LIB_LABELS: Record<LibKey, string> = {
+  tox: 'schematox',
+  zod: 'zod',
+  sup: 'superstruct',
+  val: 'valibot',
+  ajv: 'ajv',
+  yup: 'yup',
+}

--- a/benchmark/index.ts
+++ b/benchmark/index.ts
@@ -59,7 +59,10 @@ function printTable(bench: Bench) {
         library,
         'ops/sec': Math.round(ops).toLocaleString(),
         'mean (ms)': meanMs.toFixed(5),
-        'vs fastest': ops === fastestOps ? 'fastest' : `${(fastestOps / ops).toFixed(2)}x slower`,
+        'vs fastest':
+          ops === fastestOps
+            ? 'fastest'
+            : `${(fastestOps / ops).toFixed(2)}x slower`,
       }))
   )
 }
@@ -69,24 +72,73 @@ async function main() {
   await benchConstruction('primitive (string, minLength)', primitive.builders)
   await benchConstruction('flat object (3 fields)', flatObject.builders)
   await benchConstruction('nested object', nestedObject.builders)
-  await benchConstruction('array of 10 objects (schema only, not the array)', arrayShape.builders)
+  await benchConstruction(
+    'array of 10 objects (schema only, not the array)',
+    arrayShape.builders
+  )
 
-  console.log('\n\nParsing/validation (schema built once, reused across calls)\n')
+  console.log(
+    '\n\nParsing/validation (schema built once, reused across calls)\n'
+  )
 
-  await benchParse('primitive: valid subject', primitive.schemas, primitive.validSubject)
-  await benchParse('primitive: invalid subject (wrong type)', primitive.schemas, primitive.invalidSubjectWrongType)
-  await benchParse('primitive: invalid subject (too short)', primitive.schemas, primitive.invalidSubjectTooShort)
+  await benchParse(
+    'primitive: valid subject',
+    primitive.schemas,
+    primitive.validSubject
+  )
+  await benchParse(
+    'primitive: invalid subject (wrong type)',
+    primitive.schemas,
+    primitive.invalidSubjectWrongType
+  )
+  await benchParse(
+    'primitive: invalid subject (too short)',
+    primitive.schemas,
+    primitive.invalidSubjectTooShort
+  )
 
-  await benchParse('flat object: valid subject', flatObject.schemas, flatObject.validSubject)
-  await benchParse('flat object: invalid subject (wrong type)', flatObject.schemas, flatObject.invalidSubjectWrongType)
-  await benchParse('flat object: invalid subject (missing field)', flatObject.schemas, flatObject.invalidSubjectMissingField)
+  await benchParse(
+    'flat object: valid subject',
+    flatObject.schemas,
+    flatObject.validSubject
+  )
+  await benchParse(
+    'flat object: invalid subject (wrong type)',
+    flatObject.schemas,
+    flatObject.invalidSubjectWrongType
+  )
+  await benchParse(
+    'flat object: invalid subject (missing field)',
+    flatObject.schemas,
+    flatObject.invalidSubjectMissingField
+  )
 
-  await benchParse('nested object: valid subject', nestedObject.schemas, nestedObject.validSubject)
-  await benchParse('nested object: invalid subject (wrong type)', nestedObject.schemas, nestedObject.invalidSubjectWrongType)
-  await benchParse('nested object: invalid subject (missing field)', nestedObject.schemas, nestedObject.invalidSubjectMissingField)
+  await benchParse(
+    'nested object: valid subject',
+    nestedObject.schemas,
+    nestedObject.validSubject
+  )
+  await benchParse(
+    'nested object: invalid subject (wrong type)',
+    nestedObject.schemas,
+    nestedObject.invalidSubjectWrongType
+  )
+  await benchParse(
+    'nested object: invalid subject (missing field)',
+    nestedObject.schemas,
+    nestedObject.invalidSubjectMissingField
+  )
 
-  await benchParse('array (10 items): valid subject', arrayShape.schemas, arrayShape.validSubject)
-  await benchParse('array (10 items): invalid subject (wrong type in last item)', arrayShape.schemas, arrayShape.invalidSubjectWrongType)
+  await benchParse(
+    'array (10 items): valid subject',
+    arrayShape.schemas,
+    arrayShape.validSubject
+  )
+  await benchParse(
+    'array (10 items): invalid subject (wrong type in last item)',
+    arrayShape.schemas,
+    arrayShape.invalidSubjectWrongType
+  )
 }
 
 main()

--- a/benchmark/index.ts
+++ b/benchmark/index.ts
@@ -1,0 +1,92 @@
+import { Bench } from 'tinybench'
+
+import { adapters, LIB_LABELS, type LibKey } from './adapters.ts'
+
+import * as primitive from './schemas/primitive.ts'
+import * as flatObject from './schemas/flat-object.ts'
+import * as nestedObject from './schemas/nested-object.ts'
+import * as arrayShape from './schemas/array.ts'
+
+const LIB_KEYS: LibKey[] = ['tox', 'zod', 'sup', 'val', 'ajv', 'yup']
+
+async function benchConstruction(
+  label: string,
+  builders: Record<LibKey, () => unknown>
+) {
+  const bench = new Bench({ name: `construction: ${label}` })
+
+  for (const key of LIB_KEYS) {
+    bench.add(LIB_LABELS[key], () => {
+      builders[key]()
+    })
+  }
+
+  await bench.run()
+  printTable(bench)
+}
+
+async function benchParse(
+  label: string,
+  schemas: Record<LibKey, unknown>,
+  subject: unknown
+) {
+  const bench = new Bench({ name: label })
+
+  for (const key of LIB_KEYS) {
+    bench.add(LIB_LABELS[key], () => {
+      adapters[key](schemas[key], subject)
+    })
+  }
+
+  await bench.run()
+  printTable(bench)
+}
+
+function printTable(bench: Bench) {
+  const opsByTask = bench.tasks.map((task) => ({
+    library: task.name,
+    ops: task.result?.throughput.mean ?? 0,
+    meanMs: task.result?.latency.mean ?? 0,
+  }))
+
+  const fastestOps = Math.max(...opsByTask.map((t) => t.ops))
+
+  console.log(`\n${bench.name}`)
+  console.table(
+    opsByTask
+      .sort((a, b) => b.ops - a.ops)
+      .map(({ library, ops, meanMs }) => ({
+        library,
+        'ops/sec': Math.round(ops).toLocaleString(),
+        'mean (ms)': meanMs.toFixed(5),
+        'vs fastest': ops === fastestOps ? 'fastest' : `${(fastestOps / ops).toFixed(2)}x slower`,
+      }))
+  )
+}
+
+async function main() {
+  console.log('Schema construction (building the schema once)\n')
+  await benchConstruction('primitive (string, minLength)', primitive.builders)
+  await benchConstruction('flat object (3 fields)', flatObject.builders)
+  await benchConstruction('nested object', nestedObject.builders)
+  await benchConstruction('array of 10 objects (schema only, not the array)', arrayShape.builders)
+
+  console.log('\n\nParsing/validation (schema built once, reused across calls)\n')
+
+  await benchParse('primitive: valid subject', primitive.schemas, primitive.validSubject)
+  await benchParse('primitive: invalid subject (wrong type)', primitive.schemas, primitive.invalidSubjectWrongType)
+  await benchParse('primitive: invalid subject (too short)', primitive.schemas, primitive.invalidSubjectTooShort)
+
+  await benchParse('flat object: valid subject', flatObject.schemas, flatObject.validSubject)
+  await benchParse('flat object: invalid subject (wrong type)', flatObject.schemas, flatObject.invalidSubjectWrongType)
+  await benchParse('flat object: invalid subject (missing field)', flatObject.schemas, flatObject.invalidSubjectMissingField)
+
+  await benchParse('nested object: valid subject', nestedObject.schemas, nestedObject.validSubject)
+  await benchParse('nested object: invalid subject (wrong type)', nestedObject.schemas, nestedObject.invalidSubjectWrongType)
+  await benchParse('nested object: invalid subject (missing field)', nestedObject.schemas, nestedObject.invalidSubjectMissingField)
+
+  await benchParse('array (10 items): valid subject', arrayShape.schemas, arrayShape.validSubject)
+  await benchParse('array (10 items): invalid subject (wrong type in last item)', arrayShape.schemas, arrayShape.invalidSubjectWrongType)
+}
+
+main()

--- a/benchmark/package-lock.json
+++ b/benchmark/package-lock.json
@@ -1,0 +1,693 @@
+{
+  "name": "schematox-benchmark",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "schematox-benchmark",
+      "version": "0.0.1",
+      "dependencies": {
+        "ajv": "^8.17.1",
+        "superstruct": "^2.0.2",
+        "tinybench": "^3.1.1",
+        "valibot": "^1.0.0",
+        "yup": "^1.4.0",
+        "zod": "^3.23.8"
+      },
+      "devDependencies": {
+        "tsx": "^4.19.2",
+        "typescript": "^5.3.2"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/property-expr": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.6.tgz",
+      "integrity": "sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA==",
+      "license": "MIT"
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/superstruct": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-2.0.2.tgz",
+      "integrity": "sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tiny-case": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-case/-/tiny-case-1.0.3.tgz",
+      "integrity": "sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==",
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-3.1.1.tgz",
+      "integrity": "sha512-74pmf47HY/bHqamcCMGris+1AtGGsqTZ3Hc/UK4QvSmRuf/9PIF9753+c8XBh7JfX2r9KeZtVjOYjd6vFpc0qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/toposort": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
+      "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==",
+      "license": "MIT"
+    },
+    "node_modules/tsx": {
+      "version": "4.23.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
+      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/valibot": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.4.2.tgz",
+      "integrity": "sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yup": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/yup/-/yup-1.7.1.tgz",
+      "integrity": "sha512-GKHFX2nXul2/4Dtfxhozv701jLQHdf6J34YDh2cEkpqoo8le5Mg6/LrdseVLrFarmFygZTlfIhHx/QKfb/QWXw==",
+      "license": "MIT",
+      "dependencies": {
+        "property-expr": "^2.0.5",
+        "tiny-case": "^1.0.3",
+        "toposort": "^2.0.2",
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "schematox-benchmark",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "description": "Performance comparison of schematox against similar validation libraries",
+  "scripts": {
+    "bench": "tsx index.ts"
+  },
+  "dependencies": {
+    "ajv": "^8.17.1",
+    "superstruct": "^2.0.2",
+    "tinybench": "^3.1.1",
+    "valibot": "^1.0.0",
+    "yup": "^1.4.0",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "tsx": "^4.19.2",
+    "typescript": "^5.3.2"
+  }
+}

--- a/benchmark/schemas/array.ts
+++ b/benchmark/schemas/array.ts
@@ -1,0 +1,87 @@
+import * as tox from '../../src/index.ts'
+import { z } from 'zod'
+import * as sup from 'superstruct'
+import * as v from 'valibot'
+import Ajv from 'ajv'
+import * as yup from 'yup'
+
+import type { LibKey } from '../adapters.ts'
+
+// Array<{ name: string, age: number, active: boolean }>
+
+export const builders: Record<LibKey, () => unknown> = {
+  tox: () =>
+    tox.array(
+      tox.object({
+        name: tox.string(),
+        age: tox.number(),
+        active: tox.boolean(),
+      })
+    ),
+  zod: () =>
+    z.array(
+      z.object({
+        name: z.string(),
+        age: z.number(),
+        active: z.boolean(),
+      })
+    ),
+  sup: () =>
+    sup.array(
+      sup.object({
+        name: sup.string(),
+        age: sup.number(),
+        active: sup.boolean(),
+      })
+    ),
+  val: () =>
+    v.array(
+      v.object({
+        name: v.string(),
+        age: v.number(),
+        active: v.boolean(),
+      })
+    ),
+  ajv: () =>
+    new Ajv().compile({
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          age: { type: 'number' },
+          active: { type: 'boolean' },
+        },
+        required: ['name', 'age', 'active'],
+      },
+    }),
+  yup: () =>
+    yup.array(
+      yup.object({
+        name: yup.string().required(),
+        age: yup.number().required(),
+        active: yup.boolean().required(),
+      })
+    ),
+}
+
+export const schemas = {
+  tox: builders.tox(),
+  zod: builders.zod(),
+  sup: builders.sup(),
+  val: builders.val(),
+  ajv: builders.ajv(),
+  yup: builders.yup(),
+} as Record<LibKey, any>
+
+const ITEM_COUNT = 10
+
+export const validSubject = Array.from({ length: ITEM_COUNT }, (_, i) => ({
+  name: `user-${i}`,
+  age: 20 + i,
+  active: i % 2 === 0,
+}))
+
+export const invalidSubjectWrongType = validSubject.map((item, i) =>
+  i === ITEM_COUNT - 1 ? { ...item, age: 'not-a-number' } : item
+)

--- a/benchmark/schemas/flat-object.ts
+++ b/benchmark/schemas/flat-object.ts
@@ -1,0 +1,70 @@
+import * as tox from '../../src/index.ts'
+import { z } from 'zod'
+import * as sup from 'superstruct'
+import * as v from 'valibot'
+import Ajv from 'ajv'
+import * as yup from 'yup'
+
+import type { LibKey } from '../adapters.ts'
+
+// { name: string, age: number, active: boolean }
+
+export const builders: Record<LibKey, () => unknown> = {
+  tox: () =>
+    tox.object({
+      name: tox.string(),
+      age: tox.number(),
+      active: tox.boolean(),
+    }),
+  zod: () =>
+    z.object({
+      name: z.string(),
+      age: z.number(),
+      active: z.boolean(),
+    }),
+  sup: () =>
+    sup.object({
+      name: sup.string(),
+      age: sup.number(),
+      active: sup.boolean(),
+    }),
+  val: () =>
+    v.object({
+      name: v.string(),
+      age: v.number(),
+      active: v.boolean(),
+    }),
+  ajv: () =>
+    new Ajv().compile({
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+        age: { type: 'number' },
+        active: { type: 'boolean' },
+      },
+      required: ['name', 'age', 'active'],
+    }),
+  yup: () =>
+    yup.object({
+      name: yup.string().required(),
+      age: yup.number().required(),
+      active: yup.boolean().required(),
+    }),
+}
+
+export const schemas = {
+  tox: builders.tox(),
+  zod: builders.zod(),
+  sup: builders.sup(),
+  val: builders.val(),
+  ajv: builders.ajv(),
+  yup: builders.yup(),
+} as Record<LibKey, any>
+
+export const validSubject = { name: 'John', age: 30, active: true }
+export const invalidSubjectWrongType = {
+  name: 'John',
+  age: 'thirty',
+  active: true,
+}
+export const invalidSubjectMissingField = { name: 'John', active: true }

--- a/benchmark/schemas/nested-object.ts
+++ b/benchmark/schemas/nested-object.ts
@@ -1,0 +1,115 @@
+import * as tox from '../../src/index.ts'
+import { z } from 'zod'
+import * as sup from 'superstruct'
+import * as v from 'valibot'
+import Ajv from 'ajv'
+import * as yup from 'yup'
+
+import type { LibKey } from '../adapters.ts'
+
+// { user: { name: string, age: number }, meta: { createdAt: string, tags: string[] } }
+
+export const builders: Record<LibKey, () => unknown> = {
+  tox: () =>
+    tox.object({
+      user: tox.object({
+        name: tox.string(),
+        age: tox.number(),
+      }),
+      meta: tox.object({
+        createdAt: tox.string(),
+        tags: tox.array(tox.string()),
+      }),
+    }),
+  zod: () =>
+    z.object({
+      user: z.object({
+        name: z.string(),
+        age: z.number(),
+      }),
+      meta: z.object({
+        createdAt: z.string(),
+        tags: z.array(z.string()),
+      }),
+    }),
+  sup: () =>
+    sup.object({
+      user: sup.object({
+        name: sup.string(),
+        age: sup.number(),
+      }),
+      meta: sup.object({
+        createdAt: sup.string(),
+        tags: sup.array(sup.string()),
+      }),
+    }),
+  val: () =>
+    v.object({
+      user: v.object({
+        name: v.string(),
+        age: v.number(),
+      }),
+      meta: v.object({
+        createdAt: v.string(),
+        tags: v.array(v.string()),
+      }),
+    }),
+  ajv: () =>
+    new Ajv().compile({
+      type: 'object',
+      properties: {
+        user: {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+            age: { type: 'number' },
+          },
+          required: ['name', 'age'],
+        },
+        meta: {
+          type: 'object',
+          properties: {
+            createdAt: { type: 'string' },
+            tags: { type: 'array', items: { type: 'string' } },
+          },
+          required: ['createdAt', 'tags'],
+        },
+      },
+      required: ['user', 'meta'],
+    }),
+  yup: () =>
+    yup.object({
+      user: yup.object({
+        name: yup.string().required(),
+        age: yup.number().required(),
+      }),
+      meta: yup.object({
+        createdAt: yup.string().required(),
+        tags: yup.array(yup.string().required()).required(),
+      }),
+    }),
+}
+
+export const schemas = {
+  tox: builders.tox(),
+  zod: builders.zod(),
+  sup: builders.sup(),
+  val: builders.val(),
+  ajv: builders.ajv(),
+  yup: builders.yup(),
+} as Record<LibKey, any>
+
+export const validSubject = {
+  user: { name: 'John', age: 30 },
+  meta: { createdAt: '2024-01-01', tags: ['a', 'b', 'c'] },
+}
+
+export const invalidSubjectWrongType = {
+  user: { name: 'John', age: '30' },
+  meta: { createdAt: '2024-01-01', tags: ['a', 'b', 'c'] },
+}
+
+export const invalidSubjectMissingField = {
+  user: { name: 'John', age: 30 },
+  meta: { createdAt: '2024-01-01' },
+}

--- a/benchmark/schemas/primitive.ts
+++ b/benchmark/schemas/primitive.ts
@@ -1,0 +1,32 @@
+import * as tox from '../../src/index.ts'
+import { z } from 'zod'
+import * as sup from 'superstruct'
+import * as v from 'valibot'
+import Ajv from 'ajv'
+import * as yup from 'yup'
+
+import type { LibKey } from '../adapters.ts'
+
+// A string with a minLength constraint, present in every library's API.
+
+export const builders: Record<LibKey, () => unknown> = {
+  tox: () => tox.string().minLength(3),
+  zod: () => z.string().min(3),
+  sup: () => sup.size(sup.string(), 3, Infinity),
+  val: () => v.pipe(v.string(), v.minLength(3)),
+  ajv: () => new Ajv().compile({ type: 'string', minLength: 3 }),
+  yup: () => yup.string().min(3),
+}
+
+export const schemas = {
+  tox: builders.tox(),
+  zod: builders.zod(),
+  sup: builders.sup(),
+  val: builders.val(),
+  ajv: builders.ajv(),
+  yup: builders.yup(),
+} as Record<LibKey, any>
+
+export const validSubject = 'hello world'
+export const invalidSubjectWrongType = 42
+export const invalidSubjectTooShort = 'ab'

--- a/benchmark/tsconfig.json
+++ b/benchmark/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true
+  },
+  "include": ["**/*.ts"]
+}

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -62,7 +62,7 @@ function parseRecursively(
     return error([
       {
         code: ERROR_CODE.invalidSchema,
-        path: errorPath,
+        path: [...errorPath],
         schema: schema as Schema,
       },
     ])
@@ -92,7 +92,7 @@ function parseBigInt(
     return error([
       {
         code: ERROR_CODE.invalidType,
-        path: errorPath,
+        path: [...errorPath],
         schema,
       },
     ])
@@ -103,7 +103,7 @@ function parseBigInt(
       return error([
         {
           code: ERROR_CODE.invalidSchema,
-          path: errorPath,
+          path: [...errorPath],
           schema,
         },
       ])
@@ -117,7 +117,7 @@ function parseBigInt(
       return error([
         {
           code: ERROR_CODE.invalidSchema,
-          path: errorPath,
+          path: [...errorPath],
           schema,
         },
       ])
@@ -127,7 +127,7 @@ function parseBigInt(
       return error([
         {
           code: ERROR_CODE.invalidRange,
-          path: errorPath,
+          path: [...errorPath],
           schema,
         },
       ])
@@ -139,7 +139,7 @@ function parseBigInt(
       return error([
         {
           code: ERROR_CODE.invalidSchema,
-          path: errorPath,
+          path: [...errorPath],
           schema,
         },
       ])
@@ -153,7 +153,7 @@ function parseBigInt(
       return error([
         {
           code: ERROR_CODE.invalidSchema,
-          path: errorPath,
+          path: [...errorPath],
           schema,
         },
       ])
@@ -163,7 +163,7 @@ function parseBigInt(
       return error([
         {
           code: ERROR_CODE.invalidRange,
-          path: errorPath,
+          path: [...errorPath],
           schema,
         },
       ])
@@ -182,7 +182,7 @@ function parseBoolean(
     return error([
       {
         code: ERROR_CODE.invalidType,
-        path: errorPath,
+        path: [...errorPath],
         schema,
       },
     ])
@@ -200,7 +200,7 @@ function parseLiteral(
     return error([
       {
         code: ERROR_CODE.invalidType,
-        path: errorPath,
+        path: [...errorPath],
         schema,
       },
     ])
@@ -218,7 +218,7 @@ function parseNumber(
     return error([
       {
         code: ERROR_CODE.invalidType,
-        path: errorPath,
+        path: [...errorPath],
         schema,
       },
     ])
@@ -229,7 +229,7 @@ function parseNumber(
       return error([
         {
           code: ERROR_CODE.invalidSchema,
-          path: errorPath,
+          path: [...errorPath],
           schema,
         },
       ])
@@ -239,7 +239,7 @@ function parseNumber(
       return error([
         {
           code: ERROR_CODE.invalidRange,
-          path: errorPath,
+          path: [...errorPath],
           schema,
         },
       ])
@@ -251,7 +251,7 @@ function parseNumber(
       return error([
         {
           code: ERROR_CODE.invalidSchema,
-          path: errorPath,
+          path: [...errorPath],
           schema,
         },
       ])
@@ -261,7 +261,7 @@ function parseNumber(
       return error([
         {
           code: ERROR_CODE.invalidRange,
-          path: errorPath,
+          path: [...errorPath],
           schema,
         },
       ])
@@ -280,7 +280,7 @@ function parseString(
     return error([
       {
         code: ERROR_CODE.invalidType,
-        path: errorPath,
+        path: [...errorPath],
         schema,
       },
     ])
@@ -291,7 +291,7 @@ function parseString(
       return error([
         {
           code: ERROR_CODE.invalidSchema,
-          path: errorPath,
+          path: [...errorPath],
           schema,
         },
       ])
@@ -301,7 +301,7 @@ function parseString(
       return error([
         {
           code: ERROR_CODE.invalidRange,
-          path: errorPath,
+          path: [...errorPath],
           schema,
         },
       ])
@@ -313,7 +313,7 @@ function parseString(
       return error([
         {
           code: ERROR_CODE.invalidSchema,
-          path: errorPath,
+          path: [...errorPath],
           schema,
         },
       ])
@@ -323,7 +323,7 @@ function parseString(
       return error([
         {
           code: ERROR_CODE.invalidRange,
-          path: errorPath,
+          path: [...errorPath],
           schema,
         },
       ])
@@ -342,7 +342,7 @@ function parseArray(
     return error([
       {
         code: ERROR_CODE.invalidType,
-        path: errorPath,
+        path: [...errorPath],
         schema,
       },
     ])
@@ -355,7 +355,7 @@ function parseArray(
     return error([
       {
         code: ERROR_CODE.invalidSchema,
-        path: errorPath,
+        path: [...errorPath],
         schema,
       },
     ])
@@ -368,8 +368,9 @@ function parseArray(
     const nestedSchema = schema.of
     const nestedValue = subject[i]
 
-    const updatedErrorPath = [...errorPath, i]
-    const parsed = parseRecursively(updatedErrorPath, nestedSchema, nestedValue)
+    errorPath.push(i)
+    const parsed = parseRecursively(errorPath, nestedSchema, nestedValue)
+    errorPath.pop()
 
     if (parsed.error) {
       invalidSubjects = invalidSubjects ?? []
@@ -401,7 +402,7 @@ function parseArray(
 
     invalidSubjects.push({
       code: ERROR_CODE.invalidRange,
-      path: errorPath,
+      path: [...errorPath],
       schema,
     })
   }
@@ -414,7 +415,7 @@ function parseArray(
 
     invalidSubjects.push({
       code: ERROR_CODE.invalidRange,
-      path: errorPath,
+      path: [...errorPath],
       schema,
     })
   }
@@ -439,7 +440,7 @@ function parseObject(
     return error([
       {
         code: ERROR_CODE.invalidType,
-        path: errorPath,
+        path: [...errorPath],
         schema,
       },
     ])
@@ -454,8 +455,9 @@ function parseObject(
     const nestedSchema = schema.of[key] as Schema
     const nestedValue = narrowedSubj[key]
 
-    const updatedErrorPath = [...errorPath, key]
-    const parsed = parseRecursively(updatedErrorPath, nestedSchema, nestedValue)
+    errorPath.push(key)
+    const parsed = parseRecursively(errorPath, nestedSchema, nestedValue)
+    errorPath.pop()
 
     if (parsed.error) {
       invalidSubjects = invalidSubjects ?? []
@@ -491,7 +493,7 @@ function parseRecord(
     return error([
       {
         code: ERROR_CODE.invalidType,
-        path: errorPath,
+        path: [...errorPath],
         schema,
       },
     ])
@@ -504,7 +506,7 @@ function parseRecord(
     return error([
       {
         code: ERROR_CODE.invalidSchema,
-        path: errorPath,
+        path: [...errorPath],
         schema,
       },
     ])
@@ -522,12 +524,12 @@ function parseRecord(
       continue
     }
 
-    const updatedErrorPath = [...errorPath, key]
+    errorPath.push(key)
 
     let keyIsValid = true
 
     if (schema.key !== undefined) {
-      const parsedKey = parseRecursively(updatedErrorPath, schema.key, key)
+      const parsedKey = parseRecursively(errorPath, schema.key, key)
 
       if (parsedKey.error) {
         keyIsValid = false
@@ -539,7 +541,8 @@ function parseRecord(
       }
     }
 
-    const parsed = parseRecursively(updatedErrorPath, schema.of, nestedValue)
+    const parsed = parseRecursively(errorPath, schema.of, nestedValue)
+    errorPath.pop()
 
     if (parsed.error) {
       invalidSubjects = invalidSubjects ?? []
@@ -577,7 +580,7 @@ function parseRecord(
 
     invalidSubjects.push({
       code: ERROR_CODE.invalidRange,
-      path: errorPath,
+      path: [...errorPath],
       schema,
     })
   }
@@ -590,7 +593,7 @@ function parseRecord(
 
     invalidSubjects.push({
       code: ERROR_CODE.invalidRange,
-      path: errorPath,
+      path: [...errorPath],
       schema,
     })
   }
@@ -611,7 +614,7 @@ function parseTuple(
     return error([
       {
         code: ERROR_CODE.invalidSchema,
-        path: errorPath,
+        path: [...errorPath],
         schema,
       },
     ])
@@ -621,7 +624,7 @@ function parseTuple(
     return error([
       {
         code: ERROR_CODE.invalidType,
-        path: errorPath,
+        path: [...errorPath],
         schema,
       },
     ])
@@ -634,8 +637,9 @@ function parseTuple(
     const nestedSchema = schema.of[i]!
     const nestedValue = subject[i]
 
-    const updatedErrorPath = [...errorPath, i]
-    const parsed = parseRecursively(updatedErrorPath, nestedSchema, nestedValue)
+    errorPath.push(i)
+    const parsed = parseRecursively(errorPath, nestedSchema, nestedValue)
+    errorPath.pop()
 
     if (parsed.error) {
       invalidSubjects = invalidSubjects ?? []
@@ -658,7 +662,7 @@ function parseTuple(
 
     invalidSubjects.push({
       code: ERROR_CODE.invalidRange,
-      path: errorPath,
+      path: [...errorPath],
       schema,
     })
   }
@@ -679,7 +683,7 @@ function parseUnion(
     return error([
       {
         code: ERROR_CODE.invalidSchema,
-        path: errorPath,
+        path: [...errorPath],
         schema,
       },
     ])
@@ -696,7 +700,7 @@ function parseUnion(
   return error([
     {
       code: ERROR_CODE.invalidUnion,
-      path: errorPath,
+      path: [...errorPath],
       schema,
     },
   ])

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -19,17 +19,24 @@ export const success = <T>(data: T): ParseSuccess<T> => ({
 /**
  * `target[key] = value` invokes Object.prototype's `__proto__` accessor
  * for that one key name, corrupting or silently dropping the assignment.
- * defineProperty always creates a plain own data property instead.
+ * defineProperty always creates a plain own data property instead — but
+ * it's markedly slower than a direct assignment, so it's reserved for
+ * that one dangerous key and every other key takes the fast path.
  **/
 export const assignOwnProperty = (
   target: Record<string, unknown>,
   key: string,
   value: unknown
 ): void => {
-  Object.defineProperty(target, key, {
-    value,
-    writable: true,
-    enumerable: true,
-    configurable: true,
-  })
+  if (key === '__proto__') {
+    Object.defineProperty(target, key, {
+      value,
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    })
+    return
+  }
+
+  target[key] = value
 }


### PR DESCRIPTION
## Summary
- Adds a benchmark suite (`benchmark/`) comparing schematox's schema construction and parse/validation throughput against zod, superstruct, valibot, ajv, and yup, across primitive, flat object, nested object, and array shapes (valid and invalid subjects).
- The benchmark surfaced that `parse()` was 2-3x slower than zod/valibot specifically on valid-subject object/array parsing, while already competitive on fast-fail (invalid top-level type) cases — pointing at per-element overhead paid only on the success path.
- Fixes two sources of that overhead in `src/parse.ts` / `src/utils.ts`:
  - `array`/`object`/`record`/`tuple` parsing copied the error-path array (`[...errorPath, key]`) for every element regardless of whether it errored. Now the path is built via push/pop on one shared array per `parse()` call, and only copied at the point an `InvalidSubject` is actually constructed.
  - `assignOwnProperty` used `Object.defineProperty` for every assigned key, when that's only needed to guard the single dangerous key `__proto__`. Every other key now takes a plain assignment.

## Results (parsing benchmarks, schema built once and reused)
| case | before | after |
|---|---|---|
| flat object, valid | 1.67M ops/s | 4.60M ops/s (+2.8x) |
| nested object, valid | 714K ops/s | 1.93M ops/s (+2.7x) |
| array (10 items), valid | 164K ops/s | 510K ops/s (+3.1x) |
| flat object, invalid (wrong type) | 2.10M ops/s | 4.26M ops/s (+2.0x) |
| nested object, invalid (missing field) | 979K ops/s | 2.44M ops/s (+2.5x) |

schematox now matches or beats zod/valibot on these cases, up from trailing 2-3x. Schema-construction benchmarks are unaffected, as expected (the change is confined to `parse()`). No behavior change — all 302 existing tests pass, including the `__proto__` prototype-pollution suite, and `tsc --noEmit` is clean.

## Test plan
- [x] `npx vitest run` — 302/302 passing
- [x] `npx tsc --noEmit` — clean
- [x] `npm run bench` in `benchmark/` — before/after comparison captured above