### PR TITLE
docs(benchmark): add bundle size comparison against other libraries

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,6 +1,6 @@
 # Benchmarks
 
-This directory compares schematox against [zod](https://www.npmjs.com/package/zod), [valibot](https://www.npmjs.com/package/valibot), [superstruct](https://www.npmjs.com/package/superstruct), [ajv](https://www.npmjs.com/package/ajv), and [yup](https://www.npmjs.com/package/yup), using [tinybench](https://www.npmjs.com/package/tinybench). It measures two separate things — **building** a schema once, and **parsing** with an already-built schema — across four shapes (a bare primitive, a flat 3-field object, a 2-level nested object with an array field, and an array of 10 objects), each with both a valid and an invalid subject.
+This directory compares schematox against [zod](https://www.npmjs.com/package/zod), [valibot](https://www.npmjs.com/package/valibot), [superstruct](https://www.npmjs.com/package/superstruct), [ajv](https://www.npmjs.com/package/ajv), and [yup](https://www.npmjs.com/package/yup). Two things are measured: **speed**, using [tinybench](https://www.npmjs.com/package/tinybench) — both **building** a schema once and **parsing** with an already-built schema, across four shapes (a bare primitive, a flat 3-field object, a 2-level nested object with an array field, and an array of 10 objects), each with both a valid and an invalid subject — and **bundle size**, using [esbuild](https://esbuild.github.io) to bundle and minify a realistic single-schema use case.
 
 Run it yourself:
 
@@ -58,3 +58,31 @@ Numbers below were captured on Node v23.7.0, Apple M1. Absolute numbers will dif
 **Array-of-objects looks worse than flat-object for every library, including ajv — that's volume, not an array-specific weakness.** The array benchmark validates 10 nested objects (30 field checks total) per call; the flat-object benchmark validates 3. Ops/sec drops roughly in proportion to the work per call for every library in the table, ajv included, not just schematox.
 
 **superstruct and yup sit at the opposite ends of the construction/parsing tradeoff.** superstruct's schemas are cheap closures to build — fastest construction by a wide margin — but the slowest interpreter to run except against yup. yup is unusually slow on both sides: it's the only library here without a non-throwing validate API (its adapter wraps `validateSync()` in try/catch — see [`adapters.ts`](./adapters.ts)), and its schema resolution is the heaviest of the group regardless of outcome.
+
+## Bundle size (minified + gzip, smaller is better)
+
+Run it yourself:
+
+```sh
+cd benchmark
+npm install
+npm run size
+```
+
+This isn't the package's published unpacked size — it's what actually ships to a client for one realistic use case: build the same flat 3-field object schema used above, parse one subject with it, then bundle and minify with [esbuild](https://esbuild.github.io) for the browser platform and gzip the result. Unused exports get tree-shaken like they would in a real app, so the number reflects the cost of *using* a library, not owning it on disk.
+
+schematox appears twice. `schematox (struct)` is the `object()`/`string()`/... chain, authored the same way the ops/sec benchmarks above build it. `schematox (static schema)` passes a plain object literal straight to `parse()` instead — no `struct` builder at all. Both produce identical runtime behavior; this checks whether "a schema is just data" pays off in bundle size, not only in portability.
+
+| library | minified | minified + gzip | vs smallest |
+|---|---|---|---|
+| valibot | 3.18 kB | 1.21 kB | smallest |
+| superstruct | 3.38 kB | 1.43 kB | 1.19x larger |
+| schematox (static schema) | 6.18 kB | 1.54 kB | 1.28x larger |
+| schematox (struct) | 8.29 kB | 2.13 kB | 1.77x larger |
+| yup | 41.20 kB | 13.14 kB | 10.88x larger |
+| zod | 58.26 kB | 13.84 kB | 11.45x larger |
+| ajv | 115.12 kB | 35.43 kB | 29.33x larger |
+
+**schematox isn't the smallest here — valibot and superstruct both beat it, by a real margin, not noise.** Both are built from the ground up as independent, individually-importable functions with no shared runtime beyond what a given call needs. schematox's `parse()` path (shared across every schema type, coercion, and `.preprocess()`) doesn't shrink to fit a single flat object the way valibot's or superstruct's per-function design does, even with dead-code elimination doing its job. It's still 6-9x smaller than zod and yup and over 15x smaller than ajv's compiled output for the same schema — the honest claim is "meaningfully lighter than the mainstream option," not "the lightest thing here."
+
+**Authoring style changes the number, not just the portability story.** The static-schema version is ~28% smaller minified and ~28% smaller gzipped than the `struct` version, because it only pulls in `parse()` — the `struct` version also pulls in the chain-method machinery (`.optional()`, `.nullable()`, `.brand()`, `.preprocess()`, ...) that a flat object with no chained params never calls but esbuild can't fully prove away. If bundle weight is the priority for a given call site, passing a plain schema object to `parse()` directly is the smaller choice, not just the more "data-first" one.

--- a/benchmark/package-lock.json
+++ b/benchmark/package-lock.json
@@ -16,6 +16,8 @@
         "zod": "^3.23.8"
       },
       "devDependencies": {
+        "@types/node": "^22.10.2",
+        "esbuild": "^0.28.1",
         "tsx": "^4.19.2",
         "typescript": "^5.3.2"
       }
@@ -462,6 +464,16 @@
         "node": ">=18"
       }
     },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
@@ -653,6 +665,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/valibot": {
       "version": "1.4.2",

--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "description": "Performance comparison of schematox against similar validation libraries",
   "scripts": {
-    "bench": "tsx index.ts"
+    "bench": "tsx index.ts",
+    "size": "tsx size/measure.ts"
   },
   "dependencies": {
     "ajv": "^8.17.1",
@@ -16,6 +17,8 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
+    "@types/node": "^22.10.2",
+    "esbuild": "^0.28.1",
     "tsx": "^4.19.2",
     "typescript": "^5.3.2"
   }

--- a/benchmark/size/entries/ajv.ts
+++ b/benchmark/size/entries/ajv.ts
@@ -1,0 +1,12 @@
+import Ajv from 'ajv'
+
+const schema = new Ajv().compile({
+  type: 'object',
+  properties: {
+    name: { type: 'string' },
+    age: { type: 'number' },
+    active: { type: 'boolean' },
+  },
+  required: ['name', 'age', 'active'],
+})
+export const result = schema({ name: 'John', age: 30, active: true })

--- a/benchmark/size/entries/sup.ts
+++ b/benchmark/size/entries/sup.ts
@@ -1,0 +1,4 @@
+import { object, string, number, boolean, validate } from 'superstruct'
+
+const schema = object({ name: string(), age: number(), active: boolean() })
+export const result = validate({ name: 'John', age: 30, active: true }, schema)

--- a/benchmark/size/entries/tox-static.ts
+++ b/benchmark/size/entries/tox-static.ts
@@ -1,0 +1,12 @@
+import { parse } from '../../../dist/index.js'
+
+const schema = {
+  type: 'object',
+  of: {
+    name: { type: 'string' },
+    age: { type: 'number' },
+    active: { type: 'boolean' },
+  },
+} as const
+
+export const result = parse(schema, { name: 'John', age: 30, active: true })

--- a/benchmark/size/entries/tox.ts
+++ b/benchmark/size/entries/tox.ts
@@ -1,0 +1,4 @@
+import { object, string, number, boolean } from '../../../dist/index.js'
+
+const schema = object({ name: string(), age: number(), active: boolean() })
+export const result = schema.parse({ name: 'John', age: 30, active: true })

--- a/benchmark/size/entries/val.ts
+++ b/benchmark/size/entries/val.ts
@@ -1,0 +1,4 @@
+import { object, string, number, boolean, safeParse } from 'valibot'
+
+const schema = object({ name: string(), age: number(), active: boolean() })
+export const result = safeParse(schema, { name: 'John', age: 30, active: true })

--- a/benchmark/size/entries/yup.ts
+++ b/benchmark/size/entries/yup.ts
@@ -1,0 +1,12 @@
+import { object, string, number, boolean } from 'yup'
+
+const schema = object({
+  name: string().required(),
+  age: number().required(),
+  active: boolean().required(),
+})
+export const result = schema.validateSync({
+  name: 'John',
+  age: 30,
+  active: true,
+})

--- a/benchmark/size/entries/zod.ts
+++ b/benchmark/size/entries/zod.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod'
+
+const schema = z.object({
+  name: z.string(),
+  age: z.number(),
+  active: z.boolean(),
+})
+export const result = schema.safeParse({ name: 'John', age: 30, active: true })

--- a/benchmark/size/measure.ts
+++ b/benchmark/size/measure.ts
@@ -1,0 +1,80 @@
+import { gzipSync } from 'node:zlib'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import * as esbuild from 'esbuild'
+
+// Measures the real bundle weight of using each library the way its own
+// docs recommend — a flat 3-field object schema built once and parsed once
+// (the same shape as the "flat object" benchmark) — not the package's full
+// unpacked size, which includes code paths a given usage never touches.
+// Each entry is bundled and minified with esbuild for the browser platform,
+// then gzipped, so the numbers reflect what actually ships to a client.
+//
+// schematox appears twice: once authored with the `struct` builder (`object()`,
+// `string()`, ...), once with a static schema object passed straight to
+// `parse()`. The two produce identical runtime behavior, but only one of them
+// is "schema is plain data" — this checks whether that authoring choice also
+// has a bundle-size consequence, not just a portability one.
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+const LIB_LABELS = {
+  tox: 'schematox (struct)',
+  'tox-static': 'schematox (static schema)',
+  zod: 'zod',
+  sup: 'superstruct',
+  val: 'valibot',
+  ajv: 'ajv',
+  yup: 'yup',
+} as const
+
+type LibKey = keyof typeof LIB_LABELS
+
+const LIB_KEYS = Object.keys(LIB_LABELS) as LibKey[]
+
+async function measure(key: LibKey) {
+  const entryPoint = join(__dirname, 'entries', `${key}.ts`)
+
+  const result = await esbuild.build({
+    entryPoints: [entryPoint],
+    bundle: true,
+    minify: true,
+    treeShaking: true,
+    format: 'esm',
+    platform: 'browser',
+    target: 'es2020',
+    write: false,
+  })
+
+  const code = result.outputFiles[0].text
+  const minified = Buffer.byteLength(code, 'utf8')
+  const gzipped = gzipSync(Buffer.from(code, 'utf8')).length
+
+  return { key, minified, gzipped }
+}
+
+async function main() {
+  const results = []
+
+  for (const key of LIB_KEYS) {
+    results.push(await measure(key))
+  }
+
+  results.sort((a, b) => a.gzipped - b.gzipped)
+  const smallestGzip = results[0].gzipped
+
+  console.log('\nBundle size — flat object schema, built once, parsed once\n')
+  console.table(
+    results.map(({ key, minified, gzipped }) => ({
+      library: LIB_LABELS[key],
+      minified: `${(minified / 1024).toFixed(2)} kB`,
+      'minified + gzip': `${(gzipped / 1024).toFixed(2)} kB`,
+      'vs smallest':
+        gzipped === smallestGzip
+          ? 'smallest'
+          : `${(gzipped / smallestGzip).toFixed(2)}x larger`,
+    }))
+  )
+}
+
+main()


### PR DESCRIPTION
## Summary

- Adds a "Bundle size" section to `benchmark/README.md`, measured the same way the ops/sec tables are: run it yourself (`npm run size`), numbers captured on this machine, methodology and caveats explained inline.
- New `benchmark/size/` — one entry file per library, each authored the way that library's own docs recommend, bundled + minified for the browser platform with esbuild and gzipped. This measures real usage-shaped bundle weight, not npm's unpacked package size.
- schematox is measured twice: as the `struct` chain (`object()`/`string()`/...) and as a static schema object passed directly to `parse()`, to check whether "schema is data" pays off in bundle size, not only portability. It does — the static form is ~28% smaller both minified and gzipped.

## Results

| library | minified | minified + gzip | vs smallest |
|---|---|---|---|
| valibot | 3.18 kB | 1.21 kB | smallest |
| superstruct | 3.38 kB | 1.43 kB | 1.19x larger |
| schematox (static schema) | 6.18 kB | 1.54 kB | 1.28x larger |
| schematox (struct) | 8.29 kB | 2.13 kB | 1.77x larger |
| yup | 41.20 kB | 13.14 kB | 10.88x larger |
| zod | 58.26 kB | 13.84 kB | 11.45x larger |
| ajv | 115.12 kB | 35.43 kB | 29.33x larger |

Reported as-is: valibot and superstruct both beat schematox here, for the reason the README explains (they're built as independent per-function bundles with no shared runtime; schematox's `parse()` path is shared across every schema type/coercion/`.preprocess()` and doesn't shrink to fit one flat object as cleanly). schematox is still 6-9x smaller than zod/yup and >15x smaller than ajv's compiled output for the same schema — that's the honest claim this table supports, not "smallest on the page."

No CHANGELOG entry — `benchmark/` isn't published, so this doesn't affect the shipped package (consistent with earlier benchmark PRs #78/#79, neither of which touched the CHANGELOG either).

## Test plan

- [x] `npm run size` runs clean and reproduces the numbers above
- [x] `npx prettier --check` clean on all new/changed files
- [x] Added `esbuild` and `@types/node` as explicit `benchmark/` devDependencies (esbuild was previously only a transitive dep of `tsx`) and ran `npm install` to update the lockfile

🤖 Generated with [Claude Code](https://claude.com/claude-code)